### PR TITLE
Add optional gender field to registration flow

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -17,6 +17,11 @@ const UserSchema = new mongoose.Schema(
     lastName: { type: String, required: true, trim: true },
     firstName: { type: String, required: true, trim: true },
     middleName: { type: String, trim: true, default: '' },
+    gender: {
+      type: String,
+      enum: ['male', 'female'],
+      required: false,
+    },
     birthDate: { type: Date, required: true },
   },
   { timestamps: true }

--- a/src/register.html
+++ b/src/register.html
@@ -41,6 +41,18 @@
           <input type="text" name="middleName" class="auth-input" />
         </label>
 
+        <fieldset class="auth-fieldset">
+          <legend class="auth-label auth-legend">Стать (необовʼязково)</legend>
+          <label class="auth-radio">
+            <input type="radio" name="gender" value="male" />
+            <span>Чоловік</span>
+          </label>
+          <label class="auth-radio">
+            <input type="radio" name="gender" value="female" />
+            <span>Жінка</span>
+          </label>
+        </fieldset>
+
         <label class="auth-label">Дата народження
           <input type="date" name="birthDate" required class="auth-input" />
         </label>

--- a/src/scripts/auth.js
+++ b/src/scripts/auth.js
@@ -73,6 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
         lastName: formData.get('lastName'),
         firstName: formData.get('firstName'),
         middleName: formData.get('middleName') || '',
+        gender: formData.get('gender') || null,
         birthDate: formData.get('birthDate'),
       };
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -690,6 +690,36 @@ a {
   font-family: Montserrat, sans-serif;
 }
 
+.auth-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.auth-legend {
+  margin-bottom: 0;
+  font-size: 13px;
+  color: $c-gray-p;
+  font-family: Montserrat, sans-serif;
+}
+
+.auth-radio {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: Montserrat, sans-serif;
+  font-size: 14px;
+  color: $c-gray-p;
+  cursor: pointer;
+
+  input[type='radio'] {
+    accent-color: $c-green;
+  }
+}
+
 .auth-input {
    width: 100%;
    height: 42px;


### PR DESCRIPTION
## Summary
- add optional gender selection with radio buttons on the registration page and supporting styles
- store the optional gender in user records and include it in auth responses

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e035c1eec48331b8eb9568941edc09