### PR TITLE
Add FAQ section beneath subscription on homepage

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -382,6 +382,49 @@
         </div>
       </div>
     </section>
+    <section class="faq-section" id="faq-section">
+      <div class="container">
+        <div class="faq-content">
+          <h2 class="faq-title">FAQ</h2>
+          <p class="faq-description">
+            Зібрали відповіді на найпоширеніші питання відвідувачів, щоб
+            ваш похід до музею був безтурботним.
+          </p>
+          <div class="faq-list">
+            <article class="faq-item">
+              <h3 class="faq-item__question">
+                Чи можна долучитися до нічних екскурсій у NAMU?
+              </h3>
+              <p class="faq-item__answer">
+                Так, музей щомісяця організовує тематичні вечірні прогулянки
+                залами. Попередня реєстрація дає змогу зарезервувати місце та
+                отримати невеликий буклет із історіями про шедеври колекції.
+              </p>
+            </article>
+            <article class="faq-item">
+              <h3 class="faq-item__question">
+                Як підготуватися до візиту з дітьми?
+              </h3>
+              <p class="faq-item__answer">
+                На вихідних працюють родинні майстер-класи, де дітям розповідають
+                про мистецтво через гру. Рекомендуємо забронювати квитки онлайн,
+                щоб гарантовано потрапити на інтерактивну програму.
+              </p>
+            </article>
+            <article class="faq-item">
+              <h3 class="faq-item__question">
+                Чи є в музеї простір для роботи або навчання?
+              </h3>
+              <p class="faq-item__answer">
+                У бібліотеці NAMU облаштовані тихі зони з Wi-Fi та архівом
+                каталожних видань. Відвідувачі можуть працювати або навчатися,
+                відкриваючи для себе історії художників у перервах між лекціями.
+              </p>
+            </article>
+          </div>
+        </div>
+      </div>
+    </section>
     <footer
       class="footer"
       id="footer"

--- a/src/styles/_faq.scss
+++ b/src/styles/_faq.scss
@@ -1,0 +1,86 @@
+.faq-section {
+  background-color: #f5f3ef;
+  padding: 80px 0;
+
+  @media (min-width: $breakpoint-tablet) {
+    padding: 100px 0;
+  }
+
+  @media (min-width: $breakpoint-desktop) {
+    padding: 120px 0;
+  }
+}
+
+.faq-content {
+  max-width: 900px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.faq-title {
+  font-size: 32px;
+  font-weight: 700;
+  margin-bottom: 16px;
+  text-transform: uppercase;
+
+  @media (min-width: $breakpoint-tablet) {
+    font-size: 40px;
+  }
+
+  @media (min-width: $breakpoint-desktop) {
+    font-size: 48px;
+  }
+}
+
+.faq-description {
+  font-size: 16px;
+  color: $c-gray-p;
+  margin-bottom: 32px;
+
+  @media (min-width: $breakpoint-tablet) {
+    font-size: 18px;
+    margin-bottom: 40px;
+  }
+}
+
+.faq-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+
+  @media (min-width: $breakpoint-tablet) {
+    gap: 24px;
+  }
+}
+
+.faq-item {
+  background-color: $c-white;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(15, 14, 8, 0.08);
+
+  @media (min-width: $breakpoint-tablet) {
+    padding: 32px;
+  }
+
+  &__question {
+    font-size: 20px;
+    font-weight: 600;
+    margin-bottom: 12px;
+    color: $c-gray-main;
+
+    @media (min-width: $breakpoint-tablet) {
+      font-size: 22px;
+    }
+  }
+
+  &__answer {
+    font-size: 16px;
+    color: $c-gray-p;
+    line-height: 1.6;
+
+    @media (min-width: $breakpoint-tablet) {
+      font-size: 17px;
+    }
+  }
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -808,4 +808,5 @@ a {
 @import 'lecture';
 @import 'gallery';
 @import 'subscription';
+@import 'faq';
 @import 'footer';


### PR DESCRIPTION
## Summary
- add an FAQ block after the subscription section with museum-themed questions and answers
- style the FAQ layout with dedicated SCSS to match the rest of the site

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e039632e1c83319037ad8dfa0e04f9