### PR TITLE
Add masked Ukrainian phone field to registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "bcrypt": "^5.1.1",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
+    "imask": "^7.6.1",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.7.0"
   }

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -23,6 +23,7 @@ const UserSchema = new mongoose.Schema(
       required: false,
     },
     birthDate: { type: Date, required: true },
+    phone: { type: String, required: true, trim: true },
   },
   { timestamps: true }
 );

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -15,10 +15,18 @@ const signToken = (user) => {
 // POST /api/auth/register
 router.post('/register', async (req, res) => {
   try {
-    const { email, password, lastName, firstName, middleName = '', birthDate, gender } = req.body;
+    const { email, password, lastName, firstName, middleName = '', birthDate, gender, phone } = req.body;
 
-    if (!email || !password || !lastName || !firstName || !birthDate) {
-      return res.status(400).json({ message: 'Вкажіть email, пароль, прізвище, ім’я та дату народження' });
+    if (!email || !password || !lastName || !firstName || !birthDate || !phone) {
+      return res
+        .status(400)
+        .json({ message: 'Вкажіть email, пароль, прізвище, ім’я, дату народження та номер телефону' });
+    }
+
+    const normalizedPhone = String(phone).trim();
+    const ukrainePhonePattern = /^\+380 \d{2} \d{3} \d{2} \d{2}$/;
+    if (!ukrainePhonePattern.test(normalizedPhone)) {
+      return res.status(400).json({ message: 'Номер телефону має бути у форматі +380 00 000 00 00' });
     }
 
     let normalizedGender;
@@ -45,6 +53,7 @@ router.post('/register', async (req, res) => {
       firstName: String(firstName).trim(),
       middleName: String(middleName || '').trim(),
       birthDate: new Date(birthDate),
+      phone: normalizedPhone,
     };
 
     if (normalizedGender) {
@@ -68,6 +77,7 @@ router.post('/register', async (req, res) => {
         middleName: user.middleName,
         gender: user.gender || null,
         birthDate: user.birthDate,
+        phone: user.phone,
       },
     });
   } catch (err) {
@@ -108,6 +118,7 @@ router.post('/login', async (req, res) => {
         middleName: user.middleName,
         gender: user.gender || null,
         birthDate: user.birthDate,
+        phone: user.phone,
       },
     });
   } catch (err) {

--- a/src/register.html
+++ b/src/register.html
@@ -41,6 +41,20 @@
           <input type="text" name="middleName" class="auth-input" />
         </label>
 
+        <label class="auth-label">Номер телефону
+          <input
+            type="tel"
+            name="phone"
+            id="phone"
+            required
+            inputmode="tel"
+            placeholder="+380 00 000 00 00"
+            class="auth-input"
+            autocomplete="tel"
+          />
+          <p id="phoneError" class="auth-error" aria-live="polite"></p>
+        </label>
+
         <fieldset class="auth-fieldset">
           <legend class="auth-label auth-legend">Стать (необовʼязково)</legend>
           <label class="auth-radio">

--- a/src/scripts/auth.js
+++ b/src/scripts/auth.js
@@ -1,4 +1,5 @@
 import '../styles/main.scss';
+import IMask from 'imask';
 
 document.addEventListener('DOMContentLoaded', () => {
   const API_BASE =
@@ -64,9 +65,41 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   if (registerForm) {
+    const phoneInput = registerForm.querySelector('#phone');
+    const phoneError = registerForm.querySelector('#phoneError');
+    let phoneMask;
+
+    const showPhoneError = () => {
+      if (!phoneError || !phoneMask) return;
+
+      if (!phoneMask.masked.isComplete) {
+        phoneError.textContent = 'Введіть номер у форматі +380 00 000 00 00';
+      } else {
+        phoneError.textContent = '';
+      }
+    };
+
+    if (phoneInput) {
+      phoneMask = IMask(phoneInput, {
+        mask: '+{380} 00 000 00 00',
+      });
+
+      phoneInput.addEventListener('input', showPhoneError);
+      phoneInput.addEventListener('blur', showPhoneError);
+    }
+
     registerForm.addEventListener('submit', async (e) => {
       e.preventDefault();
       const formData = new FormData(registerForm);
+
+      if (!phoneMask || !phoneMask.masked.isComplete) {
+        showPhoneError();
+        if (phoneInput) {
+          phoneInput.focus();
+        }
+        return;
+      }
+
       const payload = {
         email: formData.get('email'),
         password: formData.get('password'),
@@ -75,6 +108,7 @@ document.addEventListener('DOMContentLoaded', () => {
         middleName: formData.get('middleName') || '',
         gender: formData.get('gender') || null,
         birthDate: formData.get('birthDate'),
+        phone: phoneMask.value,
       };
 
       try {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -737,6 +737,13 @@ a {
    }
  }
 
+.auth-error {
+  margin: 0;
+  font-size: 12px;
+  color: #d32f2f;
+  min-height: 14px;
+}
+
 .auth-submit {
   margin-top: 8px;
   height: 44px;


### PR DESCRIPTION
## Summary
- add a masked Ukrainian phone number field with inline validation to the registration form
- style phone validation errors and ensure the error message clears immediately when corrected
- persist the phone number on the server by extending the auth payload and user model

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e7d01ee1988331b72cfd23e2615836