### PR TITLE
Add admin management table for registered administrators

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ const mongoose = require('mongoose');
 
 const authRoutes = require('./routes/auth');
 const exposRoutes = require('./routes/expos');
+const usersRoutes = require('./routes/users');
 
 async function createApp() {
   const app = express();
@@ -21,6 +22,7 @@ async function createApp() {
   // API routes
   app.use('/api/auth', authRoutes);
   app.use('/api/expos', exposRoutes);
+  app.use('/api/users', usersRoutes);
 
   // Frontend integration
   const isProd = process.env.NODE_ENV === 'production';

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const User = require('../models/User');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.use(auth);
+
+router.get('/', async (req, res) => {
+  try {
+    const users = await User.find({}).sort({ createdAt: -1 });
+    const normalized = users.map((user) => ({
+      id: user._id.toString(),
+      email: user.email,
+      lastName: user.lastName,
+      firstName: user.firstName,
+      middleName: user.middleName || '',
+      gender: user.gender || null,
+      createdAt: user.createdAt,
+    }));
+
+    return res.json(normalized);
+  } catch (err) {
+    console.error('List admins error:', err);
+    return res.status(500).json({ message: 'Помилка сервера' });
+  }
+});
+
+router.delete('/', async (req, res) => {
+  try {
+    const ids = Array.isArray(req.body?.ids) ? req.body.ids : [];
+    const validIds = ids
+      .map((id) => (typeof id === 'string' || typeof id === 'number' ? String(id) : null))
+      .filter((id) => id && mongoose.Types.ObjectId.isValid(id));
+
+    if (!validIds.length) {
+      return res.status(400).json({ message: 'Немає користувачів для видалення' });
+    }
+
+    const result = await User.deleteMany({ _id: { $in: validIds } });
+    return res.json({
+      message: 'Користувачів видалено',
+      deletedCount: result?.deletedCount || 0,
+    });
+  } catch (err) {
+    console.error('Delete admins error:', err);
+    return res.status(500).json({ message: 'Помилка сервера' });
+  }
+});
+
+module.exports = router;

--- a/src/admin.html
+++ b/src/admin.html
@@ -48,31 +48,64 @@
     <div id="notification" class="notification" style="display:none;"></div>
 
     <main class="admin-main admin-container">
-      <h1 class="admin-title">Виставки</h1>
+      <section class="admin-section">
+        <h1 class="admin-title">Виставки</h1>
 
-      <div class="table-toolbar">
-        <button id="openCreate" class="btn btn--icon">＋ Додати виставку</button>
-        <button id="refreshTable" class="btn btn--secondary">Оновити</button>
-      </div>
+        <div class="table-toolbar">
+          <button id="openCreate" class="btn btn--icon">＋ Додати виставку</button>
+          <button id="refreshTable" class="btn btn--secondary">Оновити</button>
+        </div>
 
-      <div class="table-wrapper">
-        <table class="expos-table" id="exposTable" aria-describedby="exposCaption">
-          <caption id="exposCaption" class="visually-hidden">Таблиця виставок з діями перегляду, редагування та видалення</caption>
-          <thead>
-            <tr>
-              <th scope="col" style="width:72px">№</th>
-              <th scope="col">Назва картини</th>
-              <th scope="col" style="width:120px">Фото</th>
-              <th scope="col" style="width:220px">Автор</th>
-              <th scope="col" style="width:160px">Дата</th>
-              <th scope="col" style="width:180px">Дії</th>
-            </tr>
-          </thead>
-          <tbody id="exposTbody">
-            <!-- rows injected by admin.js -->
-          </tbody>
-        </table>
-      </div>
+        <div class="table-wrapper">
+          <table class="expos-table" id="exposTable" aria-describedby="exposCaption">
+            <caption id="exposCaption" class="visually-hidden">Таблиця виставок з діями перегляду, редагування та видалення</caption>
+            <thead>
+              <tr>
+                <th scope="col" style="width:72px">№</th>
+                <th scope="col">Назва картини</th>
+                <th scope="col" style="width:120px">Фото</th>
+                <th scope="col" style="width:220px">Автор</th>
+                <th scope="col" style="width:160px">Дата</th>
+                <th scope="col" style="width:180px">Дії</th>
+              </tr>
+            </thead>
+            <tbody id="exposTbody">
+              <!-- rows injected by admin.js -->
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="admin-section admin-section--users">
+        <div class="admin-section__header">
+          <h2 class="admin-subtitle">Зареєстровані адміністратори сайту</h2>
+          <div class="admin-users-actions">
+            <button id="deleteSelectedAdmins" class="btn btn--danger" type="button" disabled>
+              Видалити вибраних
+            </button>
+          </div>
+        </div>
+
+        <div class="table-wrapper">
+          <table class="expos-table admins-table" id="adminsTable" aria-describedby="adminsCaption">
+            <caption id="adminsCaption" class="visually-hidden">Таблиця зареєстрованих адміністраторів сайту</caption>
+            <thead>
+              <tr>
+                <th scope="col" class="checkbox-column">
+                  <input type="checkbox" id="adminsSelectAll" aria-label="Позначити всіх" />
+                </th>
+                <th scope="col">ПІБ</th>
+                <th scope="col" style="width:240px">Електронна пошта</th>
+                <th scope="col" style="width:160px">Дата реєстрації</th>
+                <th scope="col" style="width:160px">Стать</th>
+              </tr>
+            </thead>
+            <tbody id="adminsTbody">
+              <!-- rows injected by admin.js -->
+            </tbody>
+          </table>
+        </div>
+      </section>
     </main>
 
     <!-- View modal -->

--- a/src/scripts/admin.js
+++ b/src/scripts/admin.js
@@ -71,6 +71,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const tbody = document.getElementById('exposTbody');
   const refreshBtn = document.getElementById('refreshTable');
 
+  const adminsTbody = document.getElementById('adminsTbody');
+  const deleteSelectedAdminsBtn = document.getElementById('deleteSelectedAdmins');
+  const selectAllAdminsCheckbox = document.getElementById('adminsSelectAll');
+
+  let adminsData = [];
+  const selectedAdminIds = new Set();
+
   // Modals
   const viewModal = document.getElementById('viewModal');
   const closeViewBtn = document.getElementById('closeView');
@@ -203,6 +210,71 @@ document.addEventListener('DOMContentLoaded', () => {
     return `${yyyy}-${mm}-${dd}`;
   };
 
+  const fmtRegistrationDate = (value) => {
+    if (!value) return '';
+    const d = new Date(value);
+    if (Number.isNaN(d.getTime())) return '';
+    const yyyy = d.getFullYear();
+    const mm = `${d.getMonth() + 1}`.padStart(2, '0');
+    const dd = `${d.getDate()}`.padStart(2, '0');
+    return `${dd}:${mm}:${yyyy}`;
+  };
+
+  const mapGender = (value) => {
+    if (!value) return 'не вказано';
+    if (value === 'male') return 'чоловіча';
+    if (value === 'female') return 'жіноча';
+    return value;
+  };
+
+  const fullName = (user) =>
+    [user?.lastName, user?.firstName, user?.middleName]
+      .map((part) => (part || '').trim())
+      .filter(Boolean)
+      .join(' ') || '—';
+
+  const pruneSelectedAdmins = () => {
+    const validIds = new Set(adminsData.map((user) => user.id));
+    selectedAdminIds.forEach((id) => {
+      if (!validIds.has(id)) {
+        selectedAdminIds.delete(id);
+      }
+    });
+  };
+
+  const updateSelectAllAdmins = () => {
+    if (!selectAllAdminsCheckbox) return;
+    if (!adminsData.length) {
+      selectAllAdminsCheckbox.checked = false;
+      selectAllAdminsCheckbox.indeterminate = false;
+      return;
+    }
+
+    let selectedCount = 0;
+    adminsData.forEach((user) => {
+      if (selectedAdminIds.has(user.id)) selectedCount += 1;
+    });
+
+    if (selectedCount === 0) {
+      selectAllAdminsCheckbox.checked = false;
+      selectAllAdminsCheckbox.indeterminate = false;
+    } else if (selectedCount === adminsData.length) {
+      selectAllAdminsCheckbox.checked = true;
+      selectAllAdminsCheckbox.indeterminate = false;
+    } else {
+      selectAllAdminsCheckbox.checked = false;
+      selectAllAdminsCheckbox.indeterminate = true;
+    }
+  };
+
+  const updateDeleteAdminsButton = () => {
+    if (!deleteSelectedAdminsBtn) return;
+    const count = selectedAdminIds.size;
+    deleteSelectedAdminsBtn.disabled = count === 0;
+    deleteSelectedAdminsBtn.textContent =
+      count > 0 ? `Видалити вибраних (${count})` : 'Видалити вибраних';
+  };
+
   const renderRows = (data) => {
     if (!tbody) return;
     tbody.innerHTML = '';
@@ -271,6 +343,52 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   };
 
+  const renderAdmins = (data) => {
+    if (!adminsTbody) return;
+    adminsTbody.innerHTML = '';
+
+    if (!Array.isArray(data) || data.length === 0) {
+      const emptyRow = document.createElement('tr');
+      const emptyCell = document.createElement('td');
+      emptyCell.colSpan = 5;
+      emptyCell.className = 'empty-row';
+      emptyCell.textContent = 'Немає зареєстрованих адміністраторів';
+      emptyRow.appendChild(emptyCell);
+      adminsTbody.appendChild(emptyRow);
+      return;
+    }
+
+    data.forEach((user) => {
+      const tr = document.createElement('tr');
+
+      const tdCheckbox = document.createElement('td');
+      tdCheckbox.className = 'checkbox-column';
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.className = 'row-checkbox';
+      checkbox.dataset.id = user.id;
+      checkbox.checked = selectedAdminIds.has(user.id);
+      tdCheckbox.appendChild(checkbox);
+
+      const tdName = document.createElement('td');
+      tdName.className = 'cell-name';
+      tdName.textContent = fullName(user);
+
+      const tdEmail = document.createElement('td');
+      tdEmail.className = 'cell-email';
+      tdEmail.textContent = user.email || '';
+
+      const tdDate = document.createElement('td');
+      tdDate.textContent = fmtRegistrationDate(user.createdAt);
+
+      const tdGender = document.createElement('td');
+      tdGender.textContent = mapGender(user.gender);
+
+      tr.append(tdCheckbox, tdName, tdEmail, tdDate, tdGender);
+      adminsTbody.appendChild(tr);
+    });
+  };
+
   const fetchExpos = async () => {
     try {
       const res = await fetch(`${API_BASE}/api/expos`, {
@@ -288,6 +406,37 @@ document.addEventListener('DOMContentLoaded', () => {
       renderRows(data);
     } catch (err) {
       showNotification(err.message || 'Сталася помилка при завантаженні виставок', 'error');
+    }
+  };
+
+  const fetchAdmins = async () => {
+    if (!adminsTbody) return;
+    try {
+      const res = await fetch(`${API_BASE}/api/users`, {
+        headers: authHeaders(),
+      });
+      if (!res.ok) {
+        if (res.status === 401) {
+          try {
+            localStorage.removeItem('authToken');
+          } catch {}
+          window.location.href = './index.html';
+          return;
+        }
+        throw new Error('Не вдалося отримати список адміністраторів');
+      }
+
+      const data = await res.json();
+      adminsData = Array.isArray(data) ? data : [];
+      pruneSelectedAdmins();
+      renderAdmins(adminsData);
+      updateSelectAllAdmins();
+      updateDeleteAdminsButton();
+    } catch (err) {
+      showNotification(
+        err.message || 'Сталася помилка при завантаженні адміністраторів',
+        'error'
+      );
     }
   };
 
@@ -328,6 +477,17 @@ document.addEventListener('DOMContentLoaded', () => {
     return data.expo;
   };
 
+  const deleteAdmins = async (ids) => {
+    const res = await fetch(`${API_BASE}/api/users`, {
+      method: 'DELETE',
+      headers: authHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({ ids }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data?.message || 'Не вдалося видалити адміністраторів');
+    return data;
+  };
+
   const deleteExpo = async (expoId) => {
     const res = await fetch(`${API_BASE}/api/expos/${encodeURIComponent(expoId)}`, {
       method: 'DELETE',
@@ -338,6 +498,71 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   if (refreshBtn) refreshBtn.addEventListener('click', fetchExpos);
+
+  if (adminsTbody) {
+    adminsTbody.addEventListener('change', (e) => {
+      const target = e.target;
+      if (!(target instanceof HTMLInputElement) || target.type !== 'checkbox') return;
+      const id = target.dataset.id;
+      if (!id) return;
+      if (target.checked) {
+        selectedAdminIds.add(id);
+      } else {
+        selectedAdminIds.delete(id);
+      }
+      updateSelectAllAdmins();
+      updateDeleteAdminsButton();
+    });
+  }
+
+  if (selectAllAdminsCheckbox) {
+    selectAllAdminsCheckbox.addEventListener('change', () => {
+      const shouldSelectAll = selectAllAdminsCheckbox.checked;
+      selectAllAdminsCheckbox.indeterminate = false;
+      adminsData.forEach((user) => {
+        if (shouldSelectAll) {
+          selectedAdminIds.add(user.id);
+        } else {
+          selectedAdminIds.delete(user.id);
+        }
+      });
+      if (adminsTbody) {
+        const checkboxes = adminsTbody.querySelectorAll("input[type='checkbox'][data-id]");
+        checkboxes.forEach((checkbox) => {
+          checkbox.checked = shouldSelectAll;
+        });
+      }
+      updateSelectAllAdmins();
+      updateDeleteAdminsButton();
+    });
+  }
+
+  if (deleteSelectedAdminsBtn) {
+    deleteSelectedAdminsBtn.addEventListener('click', async () => {
+      if (!selectedAdminIds.size) return;
+      const ids = Array.from(selectedAdminIds);
+      const confirmation = window.confirm(
+        'Ви впевнені, що хочете видалити вибраних адміністраторів?'
+      );
+      if (!confirmation) return;
+
+      const originalText = deleteSelectedAdminsBtn.textContent;
+      deleteSelectedAdminsBtn.disabled = true;
+      deleteSelectedAdminsBtn.textContent = 'Видалення...';
+
+      try {
+        await deleteAdmins(ids);
+        selectedAdminIds.clear();
+        await fetchAdmins();
+        showNotification('Адміністраторів видалено', 'success');
+      } catch (err) {
+        showNotification(err.message || 'Не вдалося видалити адміністраторів', 'error');
+      } finally {
+        deleteSelectedAdminsBtn.textContent = originalText;
+        updateDeleteAdminsButton();
+      }
+    });
+  }
 
   if (tbody) {
     tbody.addEventListener('click', async (e) => {
@@ -446,9 +671,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Initial load with auth verification
   ensureAuth()
-    .then(() => {
+    .then(async () => {
       try { document.documentElement.style.visibility = 'visible'; } catch {}
-      return fetchExpos();
+      await Promise.all([fetchExpos(), fetchAdmins()]);
     })
     .catch(() => { /* already redirected */ });
 });

--- a/src/styles/admin.scss
+++ b/src/styles/admin.scss
@@ -73,6 +73,34 @@ body {
   padding: 24px 0 48px;
 }
 
+.admin-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 48px;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+.admin-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 8px 0 0 25px;
+
+  @media (min-width: $breakpoint-tablet) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.admin-section--users {
+  margin-top: 24px;
+}
+
 .admin-title {
   font-size: 28px;
   font-weight: 800;
@@ -81,6 +109,17 @@ body {
 
   @media (min-width: $breakpoint-tablet) {
     font-size: 36px;
+  }
+}
+
+.admin-subtitle {
+  font-size: 22px;
+  font-weight: 700;
+  color: $c-gray-main;
+  margin: 0;
+
+  @media (min-width: $breakpoint-tablet) {
+    font-size: 26px;
   }
 }
 
@@ -116,6 +155,23 @@ body {
 
     &:hover {
       background: #eaf3f1;
+    }
+  }
+
+  &--danger {
+    background: #d2332a;
+    border-color: #d2332a;
+
+    &:hover {
+      filter: brightness(0.95);
+    }
+
+    &:disabled {
+      background: #f3b5b0;
+      border-color: #f3b5b0;
+      cursor: not-allowed;
+      color: $c-white;
+      filter: none;
     }
   }
 }
@@ -180,6 +236,17 @@ body {
 .cell-num {
   width: 72px;
   font-weight: 700;
+}
+
+.checkbox-column {
+  width: 56px;
+  text-align: center;
+
+  input[type='checkbox'] {
+    width: 18px;
+    height: 18px;
+    cursor: pointer;
+  }
 }
 
 .cell-photo {
@@ -258,6 +325,25 @@ body {
 
 .view-desc {
   line-height: 1.5;
+}
+
+.admins-table {
+  min-width: 680px;
+
+  .cell-name {
+    font-weight: 600;
+  }
+
+  .empty-row {
+    text-align: center;
+    font-style: italic;
+    color: $c-gray-p;
+  }
+}
+
+.admin-users-actions {
+  display: flex;
+  gap: 12px;
 }
 /* Admin modals (scoped here to keep admin functionality) */
 .modal {


### PR DESCRIPTION
## Summary
- add a "registered administrators" table to the admin panel beneath the exhibitions list
- load administrator data from the database with selection controls and bulk deletion
- expose backend API routes to list and delete admin users and update styles for the new section

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e7de171ef88331adbc3150624f38a5