### PR TITLE
docs: elaborate backend section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,70 @@
-## Project Structure
+# Project Structure
+
+This repository is split into a few major areas. The notes below explain what
+each folder or file is for so you can find the right place to work.
+
+## Backend (`backend/`)
+
+This folder contains the Express and MongoDB server. The entry point is
+`index.js`. It loads environment variables, connects to MongoDB, and boots the
+Express app. The file registers a lightweight health check with
+`app.get('/api/health', ...)` so tooling can confirm the service is online, and
+it mounts the route modules under `/api/auth`, `/api/expos`, and `/api/users`.
+During local development the same file also starts Vite in middleware mode so
+frontend files are served alongside the API.
+
+The `routes/` directory groups the API endpoints by feature. For example
+`routes/auth.js` exposes `POST /register` and `POST /login`. Those handlers hash
+passwords with bcrypt, create or verify JWTs, and return the user payload that
+the frontend needs:
 
 ```
-├─ backend/
-│  ├─ index.js
-│  ├─ routes/
-│  ├─ models/
-│  ├─ middleware/
-│  ├─ services/
-│  ├─ utils/
-│  └─ config/
-│
-├─ frontend/
-│  ├─ admin.html
-│  ├─ index.html
-│  ├─ login.html
-│  ├─ register.html
-│  ├─ scripts/
-│  ├─ styles/
-│  ├─ images/
-│  └─ fonts/
-│
-├─ scripts/
-├─ vite.config.mjs
-├─ package.json
-└─ README.md
+const token = signToken(user);
+return res.status(200).json({ message: 'Успішний вхід', token, user: { ... } });
 ```
+
+`routes/expos.js` shows how authenticated routes work. It applies the
+authentication middleware, then uses the `Expo` model to read or mutate data.
+For instance, `router.post('/')` checks for a duplicate `expoId`, constructs a
+new document, and saves it before replying with `201`.
+
+The data layer lives in `models/`. Each file defines a Mongoose schema and
+model. `models/User.js` enforces things like a unique, trimmed email and
+restricts `gender` to either `male` or `female`, while `models/Expo.js` (not
+shown here) describes the fields stored for exhibitions.
+
+Reusable request helpers belong in `middleware/`. Currently `middleware/auth.js`
+parses the `Authorization` header, verifies the JWT (falling back to a sensible
+development secret if needed), and attaches the decoded payload to `req.user`
+before handing off to the actual route logic.
+
+Other folders (`services/`, `utils/`, and `config/`) exist so the codebase has a
+place for shared business logic, small helpers, or configuration constants as
+they are introduced. At the moment they are empty, but new features should use
+them instead of crowding routes or models.
+
+## Frontend (`frontend/`)
+
+This folder stores the user-facing website.
+
+- `index.html`, `login.html`, `register.html`, and `admin.html` are the main
+  entry pages for different parts of the app.
+- `scripts/` contains JavaScript files that power each page.
+- `styles/` holds the CSS that controls the look and feel of the site.
+- `images/` and `fonts/` keep static assets used by the interface.
+
+## Project-Level Files
+
+- `scripts/` includes development helpers such as deployment or maintenance
+  scripts.
+- `vite.config.mjs` configures Vite, the build tool used for the frontend.
+- `package.json` lists project dependencies and defines npm scripts.
+- `README.md` (this file) documents the project.
+- `node_modules/` is created by npm and contains the downloaded dependencies;
+  you normally do not edit anything here.
 
 ## Development
 
-- Main command: `npm start`
-
-
-
-
-- Run the API server: `npm run dev`
-- Build the frontend: `npm run build`
+- `npm start` runs the main development workflow defined in `package.json`.
+- `npm run dev` starts the API server in development mode.
+- `npm run build` bundles the frontend for production.


### PR DESCRIPTION
## Summary
- expand the backend section of the README with more detail on the server entry point and route mounting
- include concrete examples from the auth and expos routes along with explanations of the models and middleware
- clarify the purpose of supporting backend folders for future shared logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eacfe1818c8331bc4a3f50f6f1e4c6