### PR TITLE
Add MySQL connection helper and integrate pool

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,67 @@
+const mysql = require('mysql2/promise');
+
+let cachedPool = null;
+let cachedConnectionInfo = null;
+
+function buildPoolConfig(connectionString) {
+  if (!connectionString) {
+    throw new Error('Missing DATABASE_URL in the environment variables.');
+  }
+
+  let url;
+  try {
+    url = new URL(connectionString);
+  } catch (error) {
+    throw new Error(`Invalid DATABASE_URL provided: ${error.message}`);
+  }
+
+  const database = decodeURIComponent(url.pathname.replace(/^\//, ''));
+  const sslMode = (url.searchParams.get('ssl-mode') || '').toUpperCase();
+
+  const config = {
+    host: url.hostname,
+    port: url.port ? Number(url.port) : 3306,
+    user: decodeURIComponent(url.username),
+    password: decodeURIComponent(url.password),
+    database,
+    waitForConnections: true,
+    connectionLimit: 10,
+    queueLimit: 0,
+  };
+
+  if (sslMode === 'REQUIRED') {
+    config.ssl = { rejectUnauthorized: true };
+  }
+
+  cachedConnectionInfo = {
+    host: config.host,
+    port: config.port,
+    database: config.database,
+    sslMode: sslMode || 'DISABLED',
+  };
+
+  return config;
+}
+
+function createPool() {
+  if (cachedPool) {
+    return cachedPool;
+  }
+
+  const connectionString = process.env.DATABASE_URL;
+  const poolConfig = buildPoolConfig(connectionString);
+  cachedPool = mysql.createPool(poolConfig);
+  return cachedPool;
+}
+
+function getPool() {
+  return cachedPool || createPool();
+}
+
+const pool = getPool();
+
+module.exports = {
+  pool,
+  getPool,
+  connectionInfo: () => ({ ...cachedConnectionInfo }),
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,7 +3,8 @@ require('dotenv').config();
 const path = require('path');
 const fs = require('fs');
 const express = require('express');
-const mongoose = require('mongoose');
+
+const { pool, connectionInfo } = require('./db');
 
 const authRoutes = require('./routes/auth');
 const expoRoutes = require('./routes/expos');
@@ -76,26 +77,13 @@ async function attachFrontend(app) {
   });
 }
 
-/**
- * Connects to MongoDB using the environment variables supplied in .env.
- * A helpful message is logged if the connection string is missing so that
- * beginners immediately know what went wrong.
- */
-async function connectToDatabase() {
-  const connectionString = process.env.MONGODB_URI;
-  const databaseName = process.env.DB_NAME || 'museum';
-
-  if (!connectionString) {
-    throw new Error('Missing MONGODB_URI in the environment variables.');
-  }
-
-  await mongoose.connect(connectionString, { dbName: databaseName });
-  console.log(`Connected to MongoDB (database: ${databaseName})`);
-}
-
 async function startServer() {
   try {
-    await connectToDatabase();
+    await pool.query('SELECT 1');
+    const info = connectionInfo();
+    console.log(
+      `Connected to MySQL ${info.host}:${info.port}/${info.database} (ssl-mode=${info.sslMode})`
+    );
 
     const app = await createApp();
     const port = Number(process.env.PORT) || 3000;


### PR DESCRIPTION
## Summary
- add a reusable MySQL pool helper that parses DATABASE_URL and enforces SSL when ssl-mode=REQUIRED
- update the Express bootstrap to use the pool, run a lightweight connectivity check, and log a MySQL connection message

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eff93ca9d08331b0ece7b803f0cccc