### PR TITLE
Refactor routes to use new MySQL helpers

### DIFF
--- a/backend/models/expoModel.js
+++ b/backend/models/expoModel.js
@@ -22,17 +22,17 @@ function mapExpoRow(row) {
   };
 }
 
-async function listExpos() {
+async function selectAllExpos() {
   const [rows] = await pool.query('SELECT * FROM expos ORDER BY date ASC');
   return rows.map(mapExpoRow);
 }
 
-async function getExpoByExpoId(expoId) {
+async function selectExpoByExpoId(expoId) {
   const [rows] = await pool.query('SELECT * FROM expos WHERE expo_id = ? LIMIT 1', [expoId]);
   return mapExpoRow(rows[0]);
 }
 
-async function createExpo({ expoId, title, description, author, photoUrl, date }) {
+async function insertExpo({ expoId, title, description, author, photoUrl, date }) {
   const now = new Date();
   const [result] = await pool.query(
     `INSERT INTO expos (expo_id, title, description, author, photo_url, date, created_at, updated_at)
@@ -40,8 +40,7 @@ async function createExpo({ expoId, title, description, author, photoUrl, date }
     [expoId, title, description, author || '', photoUrl || '', date, now, now]
   );
 
-  const [rows] = await pool.query('SELECT * FROM expos WHERE id = ? LIMIT 1', [result.insertId]);
-  return mapExpoRow(rows[0]);
+  return selectExpoByExpoId(expoId);
 }
 
 async function updateExpoByExpoId(expoId, updates = {}) {
@@ -63,7 +62,7 @@ async function updateExpoByExpoId(expoId, updates = {}) {
   }
 
   if (!setClauses.length) {
-    return getExpoByExpoId(expoId);
+    return selectExpoByExpoId(expoId);
   }
 
   setClauses.push('updated_at = ?');
@@ -77,7 +76,7 @@ async function updateExpoByExpoId(expoId, updates = {}) {
     return null;
   }
 
-  return getExpoByExpoId(expoId);
+  return selectExpoByExpoId(expoId);
 }
 
 async function deleteExpoByExpoId(expoId) {
@@ -86,9 +85,13 @@ async function deleteExpoByExpoId(expoId) {
 }
 
 module.exports = {
-  listExpos,
-  getExpoByExpoId,
-  createExpo,
+  selectAllExpos,
+  selectExpoByExpoId,
+  insertExpo,
   updateExpoByExpoId,
   deleteExpoByExpoId,
+  // Legacy aliases kept for compatibility where needed.
+  listExpos: selectAllExpos,
+  getExpoByExpoId: selectExpoByExpoId,
+  createExpo: insertExpo,
 };

--- a/backend/models/userModel.js
+++ b/backend/models/userModel.js
@@ -24,17 +24,17 @@ function mapUserRow(row) {
   };
 }
 
-async function getUserByEmail(email) {
+async function findUserByEmail(email) {
   const [rows] = await pool.query('SELECT * FROM users WHERE email = ? LIMIT 1', [email]);
   return mapUserRow(rows[0]);
 }
 
-async function getUserById(id) {
+async function findUserById(id) {
   const [rows] = await pool.query('SELECT * FROM users WHERE id = ? LIMIT 1', [id]);
   return mapUserRow(rows[0]);
 }
 
-async function createUser({
+async function insertUser({
   email,
   passwordHash,
   firstName,
@@ -51,10 +51,10 @@ async function createUser({
     [email, passwordHash, firstName, lastName, middleName || '', gender || null, birthDate || null, phone || '', now, now]
   );
 
-  return getUserById(result.insertId);
+  return findUserById(result.insertId);
 }
 
-async function listUsers() {
+async function selectAdminsOrdered() {
   const [rows] = await pool.query('SELECT * FROM users ORDER BY created_at DESC');
   return rows.map(mapUserRow);
 }
@@ -64,16 +64,15 @@ async function deleteUsersByIds(ids = []) {
     return { deletedCount: 0 };
   }
 
-  const placeholders = ids.map(() => '?').join(', ');
-  const [result] = await pool.query(`DELETE FROM users WHERE id IN (${placeholders})`, ids);
+  const [result] = await pool.query('DELETE FROM users WHERE id IN (?)', [ids]);
   return { deletedCount: result.affectedRows || 0 };
 }
 
 module.exports = {
   mapUserRow,
-  getUserByEmail,
-  getUserById,
-  createUser,
-  listUsers,
+  findUserByEmail,
+  findUserById,
+  insertUser,
+  selectAdminsOrdered,
   deleteUsersByIds,
 };

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
-const UserModel = require('../models/userModel');
+const { findUserByEmail, insertUser } = require('../models/userModel');
 
 const router = express.Router();
 
@@ -77,14 +77,14 @@ router.post('/register', async (req, res) => {
       return res.status(400).json({ message: 'Gender must be either "male" or "female".' });
     }
 
-    const existingUser = await UserModel.getUserByEmail(registrationInput.email);
+    const existingUser = await findUserByEmail(registrationInput.email);
     if (existingUser) {
       return res.status(409).json({ message: 'A user with this email already exists.' });
     }
 
     const passwordHash = await bcrypt.hash(registrationInput.password, 10);
 
-    const user = await UserModel.createUser({
+    const user = await insertUser({
       email: registrationInput.email,
       passwordHash,
       firstName: registrationInput.firstName,
@@ -119,7 +119,7 @@ router.post('/login', async (req, res) => {
       return res.status(400).json({ message: 'Please provide both email and password.' });
     }
 
-    const user = await UserModel.getUserByEmail(email);
+    const user = await findUserByEmail(email);
     if (!user) {
       return res.status(401).json({ message: 'Incorrect email or password.' });
     }

--- a/backend/routes/expos.js
+++ b/backend/routes/expos.js
@@ -1,5 +1,11 @@
 const express = require('express');
-const ExpoModel = require('../models/expoModel');
+const {
+  selectAllExpos,
+  selectExpoByExpoId,
+  insertExpo,
+  updateExpoByExpoId,
+  deleteExpoByExpoId,
+} = require('../models/expoModel');
 const authenticate = require('../middleware/auth');
 
 const router = express.Router();
@@ -52,7 +58,7 @@ function buildExpoUpdate(body = {}) {
  */
 router.get('/', async (_req, res) => {
   try {
-    const expos = await ExpoModel.listExpos();
+    const expos = await selectAllExpos();
     return res.json(expos);
   } catch (error) {
     console.error('Failed to list expos:', error);
@@ -67,7 +73,7 @@ router.get('/', async (_req, res) => {
 router.get('/:expoId', async (req, res) => {
   try {
     const expoId = toCleanString(req.params.expoId);
-    const expo = await ExpoModel.getExpoByExpoId(expoId);
+    const expo = await selectExpoByExpoId(expoId);
 
     if (!expo) {
       return res.status(404).json({ message: 'Expo not found.' });
@@ -100,12 +106,12 @@ router.post('/', async (req, res) => {
       return res.status(400).json({ message: 'The provided date is not valid.' });
     }
 
-    const existingExpo = await ExpoModel.getExpoByExpoId(payload.expoId);
+    const existingExpo = await selectExpoByExpoId(payload.expoId);
     if (existingExpo) {
       return res.status(409).json({ message: 'An expo with this expoId already exists.' });
     }
 
-    const expo = await ExpoModel.createExpo(payload);
+    const expo = await insertExpo(payload);
 
     return res.status(201).json({ message: 'Expo created successfully.', expo });
   } catch (error) {
@@ -127,7 +133,7 @@ router.put('/:expoId', async (req, res) => {
       return res.status(400).json({ message: 'The provided date is not valid.' });
     }
 
-    const updatedExpo = await ExpoModel.updateExpoByExpoId(expoId, updates);
+    const updatedExpo = await updateExpoByExpoId(expoId, updates);
 
     if (!updatedExpo) {
       return res.status(404).json({ message: 'Expo not found.' });
@@ -147,7 +153,7 @@ router.put('/:expoId', async (req, res) => {
 router.delete('/:expoId', async (req, res) => {
   try {
     const expoId = toCleanString(req.params.expoId);
-    const deleted = await ExpoModel.deleteExpoByExpoId(expoId);
+    const deleted = await deleteExpoByExpoId(expoId);
 
     if (!deleted) {
       return res.status(404).json({ message: 'Expo not found.' });

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const UserModel = require('../models/userModel');
+const { selectAdminsOrdered, deleteUsersByIds } = require('../models/userModel');
 const authenticate = require('../middleware/auth');
 
 const router = express.Router();
@@ -25,7 +25,7 @@ function summarizeUser(user) {
  */
 router.get('/', async (_req, res) => {
   try {
-    const users = await UserModel.listUsers();
+    const users = await selectAdminsOrdered();
     const simplifiedUsers = users.map(summarizeUser);
     return res.json(simplifiedUsers);
   } catch (error) {
@@ -57,7 +57,7 @@ router.delete('/', async (req, res) => {
       return res.status(400).json({ message: 'Please provide at least one valid user id.' });
     }
 
-    const deletionResult = await UserModel.deleteUsersByIds(validIds);
+    const deletionResult = await deleteUsersByIds(validIds);
 
     return res.json({
       message: 'Users deleted successfully.',


### PR DESCRIPTION
## Summary
- add user model helpers for finding, inserting, listing, and deleting admins with sanitized IDs
- extend expo model helpers and update routes to reuse the MySQL helper layer
- update auth and user routes to call the new helpers while keeping response shapes intact

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68effd0074fc8331bf5cf530cedcd2a2