### PR TITLE
Add Vue-based authentication pages

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -14,25 +14,8 @@
     <link rel="stylesheet" href="./styles/main.css" />
   </head>
   <body class="auth-page" data-auth-mode="login">
-    <div class="auth-card">
-      <h1 class="auth-title">Авторизація</h1>
-      <form class="auth-form" id="loginForm">
-        <label class="auth-label">
-          Електронна пошта
-          <input class="auth-input" type="email" name="email" autocomplete="email" required />
-        </label>
-        <label class="auth-label">
-          Пароль
-          <input class="auth-input" type="password" name="password" autocomplete="current-password" required />
-        </label>
-        <button class="auth-submit" type="submit" data-redirect="admin">Увійти</button>
-      </form>
-      <p class="auth-actions">
-        Ще не маєте акаунта?
-        <a href="./register.html">Зареєструватися</a>
-      </p>
-    </div>
+    <div id="app"></div>
 
-    <script type="module" src="/scripts/auth.js"></script>
+    <script type="module" src="/src/login/main.js"></script>
   </body>
 </html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -14,56 +14,8 @@
     <link rel="stylesheet" href="./styles/main.css" />
   </head>
   <body class="auth-page" data-auth-mode="register">
-    <div class="auth-card">
-      <h1 class="auth-title">Реєстрація</h1>
-      <form class="auth-form" id="registerForm">
-        <label class="auth-label">
-          Електронна пошта
-          <input class="auth-input" type="email" name="email" autocomplete="email" required />
-        </label>
-        <label class="auth-label">
-          Пароль
-          <input class="auth-input" type="password" name="password" autocomplete="new-password" required />
-        </label>
-        <label class="auth-label">
-          Прізвище
-          <input class="auth-input" type="text" name="lastName" autocomplete="family-name" />
-        </label>
-        <label class="auth-label">
-          Імʼя
-          <input class="auth-input" type="text" name="firstName" autocomplete="given-name" />
-        </label>
-        <label class="auth-label">
-          По батькові
-          <input class="auth-input" type="text" name="middleName" autocomplete="additional-name" />
-        </label>
-        <fieldset class="auth-fieldset">
-          <legend class="auth-legend">Стать</legend>
-          <label class="auth-radio">
-            <input type="radio" name="gender" value="female" />
-            Жіноча
-          </label>
-          <label class="auth-radio">
-            <input type="radio" name="gender" value="male" />
-            Чоловіча
-          </label>
-        </fieldset>
-        <label class="auth-label">
-          Дата народження
-          <input class="auth-input" type="date" name="birthDate" />
-        </label>
-        <label class="auth-label">
-          Телефон
-          <input class="auth-input" type="tel" name="phone" placeholder="+380 00 000 00 00" />
-        </label>
-        <button class="auth-submit" type="submit" data-redirect="admin">Зареєструватися</button>
-      </form>
-      <p class="auth-actions">
-        Вже маєте акаунт?
-        <a href="./login.html">Увійти</a>
-      </p>
-    </div>
+    <div id="app"></div>
 
-    <script type="module" src="/scripts/auth.js"></script>
+    <script type="module" src="/src/register/main.js"></script>
   </body>
 </html>

--- a/frontend/src/login/main.js
+++ b/frontend/src/login/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import LoginPage from '../pages/LoginPage.vue';
+
+createApp(LoginPage).mount('#app');

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="auth-card">
+    <h1 class="auth-title">Авторизація</h1>
+    <form class="auth-form" @submit.prevent="handleSubmit">
+      <label class="auth-label">
+        Електронна пошта
+        <input
+          v-model="email"
+          class="auth-input"
+          type="email"
+          name="email"
+          autocomplete="email"
+          required
+        />
+      </label>
+      <label class="auth-label">
+        Пароль
+        <input
+          v-model="password"
+          class="auth-input"
+          type="password"
+          name="password"
+          autocomplete="current-password"
+          required
+        />
+      </label>
+      <button class="auth-submit" type="submit" data-redirect="admin">Увійти</button>
+    </form>
+    <p class="auth-actions">
+      Ще не маєте акаунта?
+      <a href="./register.html">Зареєструватися</a>
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const email = ref('');
+const password = ref('');
+
+const handleSubmit = () => {
+  window.location.href = './admin.html';
+};
+</script>

--- a/frontend/src/pages/RegisterPage.vue
+++ b/frontend/src/pages/RegisterPage.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="auth-card">
+    <h1 class="auth-title">Реєстрація</h1>
+    <form class="auth-form" @submit.prevent="handleSubmit">
+      <label class="auth-label">
+        Електронна пошта
+        <input
+          v-model="form.email"
+          class="auth-input"
+          type="email"
+          name="email"
+          autocomplete="email"
+          required
+        />
+      </label>
+      <label class="auth-label">
+        Пароль
+        <input
+          v-model="form.password"
+          class="auth-input"
+          type="password"
+          name="password"
+          autocomplete="new-password"
+          required
+        />
+      </label>
+      <label class="auth-label">
+        Прізвище
+        <input
+          v-model="form.lastName"
+          class="auth-input"
+          type="text"
+          name="lastName"
+          autocomplete="family-name"
+        />
+      </label>
+      <label class="auth-label">
+        Імʼя
+        <input
+          v-model="form.firstName"
+          class="auth-input"
+          type="text"
+          name="firstName"
+          autocomplete="given-name"
+        />
+      </label>
+      <label class="auth-label">
+        По батькові
+        <input
+          v-model="form.middleName"
+          class="auth-input"
+          type="text"
+          name="middleName"
+          autocomplete="additional-name"
+        />
+      </label>
+      <fieldset class="auth-fieldset">
+        <legend class="auth-legend">Стать</legend>
+        <label class="auth-radio">
+          <input v-model="form.gender" type="radio" name="gender" value="female" />
+          Жіноча
+        </label>
+        <label class="auth-radio">
+          <input v-model="form.gender" type="radio" name="gender" value="male" />
+          Чоловіча
+        </label>
+      </fieldset>
+      <label class="auth-label">
+        Дата народження
+        <input
+          v-model="form.birthDate"
+          class="auth-input"
+          type="date"
+          name="birthDate"
+        />
+      </label>
+      <label class="auth-label">
+        Телефон
+        <input
+          ref="phoneField"
+          v-model="form.phone"
+          class="auth-input"
+          type="tel"
+          name="phone"
+          placeholder="+380 00 000 00 00"
+        />
+      </label>
+      <button class="auth-submit" type="submit" data-redirect="admin">Зареєструватися</button>
+    </form>
+    <p class="auth-actions">
+      Вже маєте акаунт?
+      <a href="./login.html">Увійти</a>
+    </p>
+  </div>
+</template>
+
+<script setup>
+import IMask from 'imask';
+import { onBeforeUnmount, onMounted, reactive, ref } from 'vue';
+
+const form = reactive({
+  email: '',
+  password: '',
+  lastName: '',
+  firstName: '',
+  middleName: '',
+  gender: '',
+  birthDate: '',
+  phone: '',
+});
+
+const phoneField = ref(null);
+let phoneMask;
+
+onMounted(() => {
+  if (phoneField.value) {
+    phoneMask = IMask(phoneField.value, {
+      mask: '+{380} 00 000 00 00',
+      lazy: false,
+    });
+  }
+});
+
+onBeforeUnmount(() => {
+  phoneMask?.destroy();
+});
+
+const handleSubmit = () => {
+  window.location.href = './admin.html';
+};
+</script>

--- a/frontend/src/register/main.js
+++ b/frontend/src/register/main.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import RegisterPage from '../pages/RegisterPage.vue';
+
+createApp(RegisterPage).mount('#app');

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -817,10 +817,9 @@ a {
     padding: 12px 18px;
   }
 }
-/* Auth pages (login/register) */
 .auth-page {
   min-height: 100vh;
-  display: flex;
+  /* display: flex; */
   align-items: center;
   justify-content: center;
   padding: 40px 16px;
@@ -828,6 +827,7 @@ a {
 }
 
 .auth-card {
+  margin: 0 auto;
   width: 100%;
   max-width: 560px;
   background: #fff;

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "build:styles": "sass --no-source-map frontend/styles/main.scss frontend/styles/main.css && sass --no-source-map frontend/styles/admin.scss frontend/styles/admin.css"
   },
   "devDependencies": {
+    "@vitejs/plugin-vue": "^5.1.4",
     "sass": "^1.77.5",
     "vite": "^5.4.10"
   },
   "dependencies": {
-    "imask": "^7.6.1"
+    "imask": "^7.6.1",
+    "vue": "^3.5.13"
   }
 }

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'node:path';
+import vue from '@vitejs/plugin-vue';
 
 const rootDir = 'frontend';
 
 export default defineConfig({
   root: rootDir,
   base: './',
+  plugins: [vue()],
   server: {
     host: '0.0.0.0',
     port: 5173,


### PR DESCRIPTION
## Summary
- add Vue as a project dependency and enable the Vite Vue plugin
- rebuild the login and registration pages as Vue single-file components with simple form handling
- mount the new Vue pages from the existing HTML entry points

## Testing
- not run (npm install blocked by registry access restrictions)

------
https://chatgpt.com/codex/tasks/task_e_68f270d5b5908331a814c4f6da90c9df