### PR TITLE
Add MySQL-backed auth endpoints and profile page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in the values.
+DATABASE_URL=
+PORT=3000

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-# Copy this file to .env and fill in the values.
-DATABASE_URL=
-PORT=3000

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,36 @@
+const { URL } = require('url');
+const mysql = require('mysql2/promise');
+
+function createPoolFromConnectionString(connectionString) {
+  if (!connectionString) {
+    throw new Error('DATABASE_URL is not defined');
+  }
+
+  const url = new URL(connectionString);
+  const sslMode = url.searchParams.get('ssl-mode');
+
+  const shouldUseSsl = sslMode && sslMode.toUpperCase() !== 'DISABLED';
+
+  const pool = mysql.createPool({
+    host: url.hostname,
+    port: Number(url.port || 3306),
+    user: decodeURIComponent(url.username || ''),
+    password: decodeURIComponent(url.password || ''),
+    database: decodeURIComponent(url.pathname.replace(/^\//, '')),
+    waitForConnections: true,
+    connectionLimit: 10,
+    queueLimit: 0,
+    dateStrings: true,
+    ssl: shouldUseSsl ? { rejectUnauthorized: false } : undefined,
+  });
+
+  return pool;
+}
+
+const connectionString =
+  process.env.DATABASE_URL ||
+  'mysql://doadmin:password@db-mysql-ams3-62405-do-user-27591002-0.e.db.ondigitalocean.com:25060/museum?ssl-mode=REQUIRED';
+
+const pool = createPoolFromConnectionString(connectionString);
+
+module.exports = { pool, createPoolFromConnectionString };

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,3 +1,5 @@
+require('dotenv').config();
+
 const { URL } = require('url');
 const mysql = require('mysql2/promise');
 
@@ -27,9 +29,7 @@ function createPoolFromConnectionString(connectionString) {
   return pool;
 }
 
-const connectionString =
-  process.env.DATABASE_URL ||
-  'mysql://doadmin:password@db-mysql-ams3-62405-do-user-27591002-0.e.db.ondigitalocean.com:25060/museum?ssl-mode=REQUIRED';
+const connectionString = process.env.DATABASE_URL;
 
 const pool = createPoolFromConnectionString(connectionString);
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,161 @@
+const express = require('express');
+const cors = require('cors');
+const bcrypt = require('bcrypt');
+const { pool } = require('./db');
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+function mapUser(dbRow) {
+  if (!dbRow) {
+    return null;
+  }
+
+  return {
+    id: dbRow.id,
+    firstName: dbRow.first_name,
+    lastName: dbRow.last_name,
+    birthDate: dbRow.birth_date,
+    gender: dbRow.gender,
+    email: dbRow.email,
+    phone: dbRow.phone,
+  };
+}
+
+function normalizePhone(phone) {
+  if (!phone) {
+    return null;
+  }
+
+  const cleaned = phone.replace(/\s+/g, '');
+  return cleaned.length ? cleaned : null;
+}
+
+app.post('/api/register', async (req, res) => {
+  const {
+    firstName,
+    lastName,
+    birthDate,
+    gender = null,
+    email,
+    phone = null,
+    password,
+  } = req.body || {};
+
+  if (!firstName || !lastName || !birthDate || !email || !password) {
+    return res
+      .status(400)
+      .json({ error: 'Будь ласка, заповніть усі обов\'язкові поля.' });
+  }
+
+  try {
+    const trimmedFirstName = firstName.trim();
+    const trimmedLastName = lastName.trim();
+    const normalizedEmail = email.trim().toLowerCase();
+
+    if (!trimmedFirstName || !trimmedLastName || !normalizedEmail) {
+      return res
+        .status(400)
+        .json({ error: 'Будь ласка, перевірте коректність введених даних.' });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+    const normalizedPhone = normalizePhone(phone);
+
+    const [result] = await pool.execute(
+      `INSERT INTO Users (first_name, last_name, birth_date, gender, email, phone, password)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`
+        .replace(/\s+/g, ' '),
+      [
+        trimmedFirstName,
+        trimmedLastName,
+        birthDate,
+        gender || null,
+        normalizedEmail,
+        normalizedPhone,
+        hashedPassword,
+      ]
+    );
+
+    const userId = result.insertId;
+
+    const [rows] = await pool.execute(
+      `SELECT id, first_name, last_name, birth_date, gender, email, phone
+         FROM Users
+        WHERE id = ?`,
+      [userId]
+    );
+
+    const user = mapUser(rows[0]);
+    return res.status(201).json({ user });
+  } catch (error) {
+    if (error && error.code === 'ER_DUP_ENTRY') {
+      return res
+        .status(409)
+        .json({ error: 'Користувач з такою електронною поштою вже існує.' });
+    }
+
+    console.error('Register error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Сталася помилка під час створення користувача.' });
+  }
+});
+
+app.post('/api/login', async (req, res) => {
+  const { email, password } = req.body || {};
+
+  if (!email || !password) {
+    return res
+      .status(400)
+      .json({ error: 'Необхідно вказати електронну пошту та пароль.' });
+  }
+
+  try {
+    const [rows] = await pool.execute(
+      `SELECT id, first_name, last_name, birth_date, gender, email, phone, password
+         FROM Users
+        WHERE email = ?`,
+      [email.trim().toLowerCase()]
+    );
+
+    if (!rows.length) {
+      return res
+        .status(401)
+        .json({ error: 'Невірна електронна пошта або пароль.' });
+    }
+
+    const dbUser = rows[0];
+    const passwordsMatch = await bcrypt.compare(password, dbUser.password);
+
+    if (!passwordsMatch) {
+      return res
+        .status(401)
+        .json({ error: 'Невірна електронна пошта або пароль.' });
+    }
+
+    const user = mapUser(dbUser);
+    return res.json({ user });
+  } catch (error) {
+    console.error('Login error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Сталася помилка під час авторизації.' });
+  }
+});
+
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+const PORT = process.env.PORT || 3000;
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server is running on port ${PORT}`);
+  });
+}
+
+module.exports = { app };

--- a/frontend/Exhibitions.html
+++ b/frontend/Exhibitions.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Мої виставки — NAMU</title>
+    <link rel="icon" type="image/x-icon" href="./images/NAMU_logo.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./styles/main.css" />
+  </head>
+  <body class="auth-page">
+    <div class="auth-card">
+      <h1 class="auth-title">Мій профіль</h1>
+      <p class="auth-actions" id="user-email"></p>
+      <div class="table-wrapper">
+        <table class="profile-table">
+          <tbody id="profile-table-body"></tbody>
+        </table>
+      </div>
+      <div class="auth-actions">
+        <button class="auth-submit" id="logout-button" type="button">Вийти</button>
+      </div>
+    </div>
+
+    <script type="module" src="./scripts/exhibitions.js"></script>
+  </body>
+</html>

--- a/frontend/scripts/exhibitions.js
+++ b/frontend/scripts/exhibitions.js
@@ -1,0 +1,68 @@
+const profileTableBody = document.getElementById('profile-table-body');
+const emailElement = document.getElementById('user-email');
+const logoutButton = document.getElementById('logout-button');
+
+function renderUserDetails(user) {
+  if (!user || !profileTableBody) {
+    return;
+  }
+
+  const rows = [
+    { label: "Ім'я", value: user.firstName || '-' },
+    { label: 'Прізвище', value: user.lastName || '-' },
+    { label: 'Дата народження', value: user.birthDate || '-' },
+    { label: 'Стать', value: user.gender || '-' },
+    { label: 'Телефон', value: user.phone || '-' },
+  ];
+
+  profileTableBody.innerHTML = '';
+
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    const tdLabel = document.createElement('td');
+    tdLabel.textContent = row.label;
+    tdLabel.className = 'profile-table__label';
+
+    const tdValue = document.createElement('td');
+    tdValue.textContent = row.value;
+    tdValue.className = 'profile-table__value';
+
+    tr.appendChild(tdLabel);
+    tr.appendChild(tdValue);
+    profileTableBody.appendChild(tr);
+  });
+}
+
+function init() {
+  const storedUser = localStorage.getItem('museumUser');
+
+  if (!storedUser) {
+    window.location.href = './login.html';
+    return;
+  }
+
+  let user;
+  try {
+    user = JSON.parse(storedUser);
+  } catch (error) {
+    console.error('Unable to parse user data', error);
+    localStorage.removeItem('museumUser');
+    window.location.href = './login.html';
+    return;
+  }
+
+  if (emailElement) {
+    emailElement.textContent = user.email || '';
+  }
+
+  renderUserDetails(user);
+}
+
+if (logoutButton) {
+  logoutButton.addEventListener('click', () => {
+    localStorage.removeItem('museumUser');
+    window.location.href = './login.html';
+  });
+}
+
+init();

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -109,7 +109,7 @@ const markTouched = (field) => {
 const emailErrorVisible = computed(() => touched.email && Boolean(errors.email));
 const passwordErrorVisible = computed(() => touched.password && Boolean(errors.password));
 
-const handleSubmit = () => {
+const handleSubmit = async () => {
   markTouched('email');
   markTouched('password');
 
@@ -117,14 +117,39 @@ const handleSubmit = () => {
     return;
   }
 
-  alert('Вхід успішний!');
+  try {
+    const response = await fetch('/api/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        email: email.value,
+        password: password.value,
+      }),
+    });
 
-  email.value = '';
-  password.value = '';
+    const payload = await response.json().catch(() => ({}));
 
-  touched.email = false;
-  touched.password = false;
-  errors.email = '';
-  errors.password = '';
+    if (!response.ok) {
+      throw new Error(payload.error || 'Не вдалося увійти.');
+    }
+
+    if (payload.user) {
+      localStorage.setItem('museumUser', JSON.stringify(payload.user));
+    }
+
+    email.value = '';
+    password.value = '';
+
+    touched.email = false;
+    touched.password = false;
+    errors.email = '';
+    errors.password = '';
+
+    window.location.href = './Exhibitions.html';
+  } catch (error) {
+    alert(error.message || 'Не вдалося увійти.');
+  }
 };
 </script>

--- a/frontend/src/pages/RegisterPage.vue
+++ b/frontend/src/pages/RegisterPage.vue
@@ -409,7 +409,7 @@ const resetForm = () => {
   });
 };
 
-const handleSubmit = () => {
+const handleSubmit = async () => {
   markTouched("email");
   markTouched("password");
   markTouched("lastName");
@@ -430,7 +430,39 @@ const handleSubmit = () => {
     return;
   }
 
-  resetForm();
+  try {
+    const response = await fetch("/api/register", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email: form.email,
+        password: form.password,
+        lastName: form.lastName,
+        firstName: form.firstName,
+        middleName: form.middleName,
+        gender: form.gender,
+        birthDate: form.birthDate,
+        phone: form.phone,
+      }),
+    });
+
+    const payload = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      throw new Error(payload.error || "Не вдалося зареєструватися.");
+    }
+
+    if (payload.user) {
+      localStorage.setItem("museumUser", JSON.stringify(payload.user));
+    }
+
+    resetForm();
+    window.location.href = "./Exhibitions.html";
+  } catch (error) {
+    alert(error.message || "Не вдалося зареєструватися.");
+  }
 };
 
 

--- a/frontend/src/pages/RegisterPage.vue
+++ b/frontend/src/pages/RegisterPage.vue
@@ -64,22 +64,6 @@
           {{ errors.firstName }}
         </p>
       </label>
-      <label class="auth-label">
-        По батькові
-        <input
-          v-model="form.middleName"
-          class="auth-input"
-          :class="{ 'auth-input--error': middleNameErrorVisible }"
-          type="text"
-          name="middleName"
-          autocomplete="additional-name"
-          required
-          @blur="markTouched('middleName')"
-        />
-        <p v-if="middleNameErrorVisible" class="auth-error">
-          {{ errors.middleName }}
-        </p>
-      </label>
       <fieldset class="auth-fieldset">
         <legend class="auth-legend">Стать</legend>
         <label class="auth-radio">
@@ -156,7 +140,6 @@ const form = reactive({
   password: "",
   lastName: "",
   firstName: "",
-  middleName: "",
   gender: "",
   birthDate: "",
   phone: "",
@@ -170,7 +153,6 @@ const errors = reactive({
   password: "",
   lastName: "",
   firstName: "",
-  middleName: "",
   birthDate: "",
   phone: "",
 });
@@ -180,7 +162,6 @@ const touched = reactive({
   password: false,
   lastName: false,
   firstName: false,
-  middleName: false,
   birthDate: false,
   phone: false,
 });
@@ -238,14 +219,6 @@ const validateFirstName = (value) => {
   return "";
 };
 
-const validateMiddleName = (value) => {
-  if (!value.trim()) {
-    return "Введіть по батькові";
-  }
-
-  return "";
-};
-
 const validateBirthDate = (value) => {
   if (!value) {
     return "Оберіть дату народження";
@@ -280,10 +253,6 @@ const updateError = (field) => {
 
   if (field === "firstName") {
     errors.firstName = validateFirstName(form.firstName);
-  }
-
-  if (field === "middleName") {
-    errors.middleName = validateMiddleName(form.middleName);
   }
 
   if (field === "birthDate") {
@@ -332,15 +301,6 @@ watch(
 );
 
 watch(
-  () => form.middleName,
-  () => {
-    if (touched.middleName) {
-      updateError("middleName");
-    }
-  }
-);
-
-watch(
   () => form.birthDate,
   () => {
     if (touched.birthDate) {
@@ -375,9 +335,6 @@ const lastNameErrorVisible = computed(
 const firstNameErrorVisible = computed(
   () => touched.firstName && Boolean(errors.firstName)
 );
-const middleNameErrorVisible = computed(
-  () => touched.middleName && Boolean(errors.middleName)
-);
 const birthDateErrorVisible = computed(
   () => touched.birthDate && Boolean(errors.birthDate)
 );
@@ -390,7 +347,6 @@ const resetForm = () => {
   form.password = "";
   form.lastName = "";
   form.firstName = "";
-  form.middleName = "";
   form.gender = "";
   form.birthDate = "";
   form.phone = "";
@@ -414,7 +370,6 @@ const handleSubmit = async () => {
   markTouched("password");
   markTouched("lastName");
   markTouched("firstName");
-  markTouched("middleName");
   markTouched("birthDate");
   markTouched("phone");
 
@@ -423,7 +378,6 @@ const handleSubmit = async () => {
     errors.password ||
     errors.lastName ||
     errors.firstName ||
-    errors.middleName ||
     errors.birthDate ||
     errors.phone
   ) {
@@ -441,7 +395,6 @@ const handleSubmit = async () => {
         password: form.password,
         lastName: form.lastName,
         firstName: form.firstName,
-        middleName: form.middleName,
         gender: form.gender,
         birthDate: form.birthDate,
         phone: form.phone,

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -186,6 +186,38 @@
   height: auto;
 }
 
+.table-wrapper {
+  margin-top: 16px;
+  overflow-x: auto;
+}
+
+.profile-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: Montserrat, sans-serif;
+}
+
+.profile-table tr:nth-child(even) {
+  background-color: #f6f8f9;
+}
+
+.profile-table__label,
+.profile-table__value {
+  padding: 12px 16px;
+  border-bottom: 1px solid #dfe5e8;
+  font-size: 14px;
+  color: #333;
+}
+
+.profile-table__label {
+  font-weight: 600;
+  width: 40%;
+}
+
+.profile-table__value {
+  word-break: break-word;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/package.json
+++ b/package.json
@@ -6,14 +6,19 @@
     "start": "vite",
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node backend/server.js"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.1.4",
     "vite": "^5.4.10"
   },
   "dependencies": {
+    "bcrypt": "^5.1.1",
+    "cors": "^2.8.5",
+    "express": "^4.21.1",
     "imask": "^7.6.1",
+    "mysql2": "^3.11.5",
     "vue": "^3.5.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "imask": "^7.6.1",
     "mysql2": "^3.11.5",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,16 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "vite",
-    "dev": "vite",
+    "dev": "concurrently -k \"npm:server\" \"npm:client\"",
+    "client": "vite",
+    "server": "node backend/server.js",
     "build": "vite build",
     "preview": "vite preview",
-    "server": "node backend/server.js"
+    "start": "node backend/server.js"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.1.4",
+    "concurrently": "^9.1.0",
     "vite": "^5.4.10"
   },
   "dependencies": {

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -11,6 +11,12 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
   },
   build: {
     outDir: '../dist',
@@ -20,6 +26,7 @@ export default defineConfig({
         main: resolve(__dirname, `${rootDir}/index.html`),
         login: resolve(__dirname, `${rootDir}/login.html`),
         register: resolve(__dirname, `${rootDir}/register.html`),
+        exhibitions: resolve(__dirname, `${rootDir}/Exhibitions.html`),
       },
     },
   },


### PR DESCRIPTION
## Summary
- add an Express API that connects to MySQL, hashes passwords with bcrypt, and exposes login/registration endpoints
- update the Vue login and registration forms to call the API, persist the returned user profile, and redirect to the new exhibitions page
- create the exhibitions profile page, supporting styles, and Vite proxy/build updates for the new route

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_69034625a7988331be90128cb7b8dcf4