### PR TITLE
Add npm start script to run backend and frontend without concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,15 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently -k \"npm:server\" \"npm:client\"",
+    "dev": "node start.js",
     "client": "vite",
     "server": "node backend/server.js",
     "build": "vite build",
     "preview": "vite preview",
-    "start": "node backend/server.js"
+    "start": "node start.js"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.1.4",
-    "concurrently": "^9.1.0",
     "vite": "^5.4.10"
   },
   "dependencies": {

--- a/start.js
+++ b/start.js
@@ -1,0 +1,44 @@
+const { spawn } = require('child_process');
+
+const processes = new Set();
+let shuttingDown = false;
+
+function terminateAll(code = 0) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const proc of processes) {
+    if (!proc.killed) {
+      proc.kill('SIGINT');
+    }
+  }
+  // give processes some time to shut down gracefully
+  setTimeout(() => process.exit(code), 100);
+}
+
+function runProcess(command, args, name) {
+  const child = spawn(command, args, { stdio: 'inherit', shell: process.platform === 'win32' });
+  processes.add(child);
+
+  child.on('exit', (code, signal) => {
+    processes.delete(child);
+    if (!shuttingDown) {
+      if (code !== 0) {
+        console.error(`${name} exited with code ${code}${signal ? ` (signal ${signal})` : ''}`);
+      }
+      terminateAll(code ?? 0);
+    }
+  });
+
+  child.on('error', (error) => {
+    console.error(`Failed to start ${name}:`, error);
+    terminateAll(1);
+  });
+}
+
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+runProcess('node', ['backend/server.js'], 'Backend');
+runProcess(npmCmd, ['run', 'client'], 'Frontend');
+
+process.on('SIGINT', () => terminateAll(0));
+process.on('SIGTERM', () => terminateAll(0));

--- a/start.js
+++ b/start.js
@@ -11,7 +11,6 @@ function terminateAll(code = 0) {
       proc.kill('SIGINT');
     }
   }
-  // give processes some time to shut down gracefully
   setTimeout(() => process.exit(code), 100);
 }
 


### PR DESCRIPTION
## Summary
- add a Node-based orchestrator script that starts the backend and frontend together
- update npm scripts to use the new orchestrator and drop the concurrently dependency

## Testing
- Not run (per user instruction)


------
https://chatgpt.com/codex/tasks/task_e_69037fbda12883319491feb9d6ada645