### PR TITLE
Add admin panel for managing exhibitions

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -24,6 +24,62 @@ function mapUser(dbRow) {
   };
 }
 
+function mapAdmin(dbRow) {
+  if (!dbRow) {
+    return null;
+  }
+
+  return {
+    id: dbRow.id,
+    firstName: dbRow.first_name,
+    lastName: dbRow.last_name,
+    gender: dbRow.gender,
+    email: dbRow.email,
+    phone: dbRow.phone,
+  };
+}
+
+function mapExhibition(dbRow) {
+  if (!dbRow) {
+    return null;
+  }
+
+  return {
+    id: dbRow.id,
+    name: dbRow.name,
+    imageUrl: dbRow.image_url,
+    startDate: dbRow.start_date,
+    endDate: dbRow.end_date,
+    availableSeats: dbRow.available_seats,
+    adminId: dbRow.admin_id,
+    adminName: dbRow.admin_name || null,
+  };
+}
+
+async function requireAdmin(adminId) {
+  if (!adminId) {
+    return null;
+  }
+
+  const [rows] = await pool.execute(
+    `SELECT id, first_name, last_name, gender, email, phone
+       FROM Admins
+      WHERE id = ?`,
+    [adminId]
+  );
+
+  return rows.length ? mapAdmin(rows[0]) : null;
+}
+
+function parseAdminId(headerValue) {
+  if (!headerValue) {
+    return null;
+  }
+
+  const id = Number(headerValue);
+  return Number.isFinite(id) ? id : null;
+}
+
 function normalizePhone(phone) {
   if (!phone) {
     return null;
@@ -143,6 +199,250 @@ app.post('/api/login', async (req, res) => {
     return res
       .status(500)
       .json({ error: 'Сталася помилка під час авторизації.' });
+  }
+});
+
+app.post('/api/admin/login', async (req, res) => {
+  const { email, password } = req.body || {};
+
+  if (!email || !password) {
+    return res
+      .status(400)
+      .json({ error: 'Необхідно вказати електронну пошту та пароль.' });
+  }
+
+  try {
+    const [rows] = await pool.execute(
+      `SELECT id, first_name, last_name, gender, email, phone, password
+         FROM Admins
+        WHERE email = ?`,
+      [email.trim().toLowerCase()]
+    );
+
+    if (!rows.length) {
+      return res
+        .status(401)
+        .json({ error: 'Невірна електронна пошта або пароль.' });
+    }
+
+    const adminRow = rows[0];
+    const passwordsMatch = await bcrypt.compare(password, adminRow.password);
+
+    if (!passwordsMatch) {
+      return res
+        .status(401)
+        .json({ error: 'Невірна електронна пошта або пароль.' });
+    }
+
+    const admin = mapAdmin(adminRow);
+    return res.json({ admin });
+  } catch (error) {
+    console.error('Admin login error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Сталася помилка під час авторизації.' });
+  }
+});
+
+app.get('/api/admin/exhibitions', async (req, res) => {
+  try {
+    const adminId = parseAdminId(req.header('x-admin-id'));
+    const admin = await requireAdmin(adminId);
+
+    if (!admin) {
+      return res.status(401).json({ error: 'Необхідно увійти як адміністратор.' });
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT e.id, e.name, e.image_url, e.start_date, e.end_date, e.available_seats, e.admin_id,
+              CONCAT(a.first_name, ' ', a.last_name) AS admin_name
+         FROM Exhibitions e
+         JOIN Admins a ON e.admin_id = a.id
+        ORDER BY e.start_date, e.id`
+    );
+
+    const exhibitions = rows.map(mapExhibition);
+    return res.json({ exhibitions });
+  } catch (error) {
+    console.error('Fetch exhibitions error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Не вдалося отримати список виставок.' });
+  }
+});
+
+app.post('/api/admin/exhibitions', async (req, res) => {
+  const adminId = parseAdminId(req.header('x-admin-id'));
+
+  try {
+    const admin = await requireAdmin(adminId);
+
+    if (!admin) {
+      return res.status(401).json({ error: 'Необхідно увійти як адміністратор.' });
+    }
+
+    const {
+      name,
+      imageUrl = null,
+      startDate,
+      endDate,
+      availableSeats,
+    } = req.body || {};
+
+    if (!name || !startDate || !endDate || availableSeats === undefined) {
+      return res
+        .status(400)
+        .json({ error: 'Будь ласка, заповніть усі обов\'язкові поля.' });
+    }
+
+    const trimmedName = name.trim();
+    const seatsNumber = Number(availableSeats);
+
+    if (!trimmedName || !Number.isFinite(seatsNumber)) {
+      return res
+        .status(400)
+        .json({ error: 'Перевірте правильність введених даних.' });
+    }
+
+    const [result] = await pool.execute(
+      `INSERT INTO Exhibitions (name, image_url, start_date, end_date, available_seats, admin_id)
+       VALUES (?, ?, ?, ?, ?, ?)`
+        .replace(/\s+/g, ' '),
+      [trimmedName, imageUrl || null, startDate, endDate, seatsNumber, admin.id]
+    );
+
+    const [rows] = await pool.execute(
+      `SELECT e.id, e.name, e.image_url, e.start_date, e.end_date, e.available_seats, e.admin_id,
+              CONCAT(a.first_name, ' ', a.last_name) AS admin_name
+         FROM Exhibitions e
+         JOIN Admins a ON e.admin_id = a.id
+        WHERE e.id = ?`,
+      [result.insertId]
+    );
+
+    const exhibition = mapExhibition(rows[0]);
+    return res.status(201).json({ exhibition });
+  } catch (error) {
+    console.error('Create exhibition error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Не вдалося створити виставку.' });
+  }
+});
+
+app.put('/api/admin/exhibitions/:id', async (req, res) => {
+  const adminId = parseAdminId(req.header('x-admin-id'));
+  const exhibitionId = Number(req.params.id);
+
+  if (!Number.isFinite(exhibitionId)) {
+    return res.status(400).json({ error: 'Некоректний ідентифікатор виставки.' });
+  }
+
+  try {
+    const admin = await requireAdmin(adminId);
+
+    if (!admin) {
+      return res.status(401).json({ error: 'Необхідно увійти як адміністратор.' });
+    }
+
+    const {
+      name,
+      imageUrl = null,
+      startDate,
+      endDate,
+      availableSeats,
+    } = req.body || {};
+
+    if (!name || !startDate || !endDate || availableSeats === undefined) {
+      return res
+        .status(400)
+        .json({ error: 'Будь ласка, заповніть усі обов\'язкові поля.' });
+    }
+
+    const trimmedName = name.trim();
+    const seatsNumber = Number(availableSeats);
+
+    if (!trimmedName || !Number.isFinite(seatsNumber)) {
+      return res
+        .status(400)
+        .json({ error: 'Перевірте правильність введених даних.' });
+    }
+
+    await pool.execute(
+      `UPDATE Exhibitions
+          SET name = ?,
+              image_url = ?,
+              start_date = ?,
+              end_date = ?,
+              available_seats = ?,
+              admin_id = ?
+        WHERE id = ?`
+        .replace(/\s+/g, ' '),
+      [
+        trimmedName,
+        imageUrl || null,
+        startDate,
+        endDate,
+        seatsNumber,
+        admin.id,
+        exhibitionId,
+      ]
+    );
+
+    const [rows] = await pool.execute(
+      `SELECT e.id, e.name, e.image_url, e.start_date, e.end_date, e.available_seats, e.admin_id,
+              CONCAT(a.first_name, ' ', a.last_name) AS admin_name
+         FROM Exhibitions e
+         JOIN Admins a ON e.admin_id = a.id
+        WHERE e.id = ?`,
+      [exhibitionId]
+    );
+
+    const exhibition = rows.length ? mapExhibition(rows[0]) : null;
+
+    if (!exhibition) {
+      return res.status(404).json({ error: 'Виставку не знайдено.' });
+    }
+
+    return res.json({ exhibition });
+  } catch (error) {
+    console.error('Update exhibition error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Не вдалося оновити виставку.' });
+  }
+});
+
+app.delete('/api/admin/exhibitions/:id', async (req, res) => {
+  const adminId = parseAdminId(req.header('x-admin-id'));
+  const exhibitionId = Number(req.params.id);
+
+  if (!Number.isFinite(exhibitionId)) {
+    return res.status(400).json({ error: 'Некоректний ідентифікатор виставки.' });
+  }
+
+  try {
+    const admin = await requireAdmin(adminId);
+
+    if (!admin) {
+      return res.status(401).json({ error: 'Необхідно увійти як адміністратор.' });
+    }
+
+    const [result] = await pool.execute(
+      `DELETE FROM Exhibitions WHERE id = ?`,
+      [exhibitionId]
+    );
+
+    if (!result.affectedRows) {
+      return res.status(404).json({ error: 'Виставку не знайдено.' });
+    }
+
+    return res.status(204).send();
+  } catch (error) {
+    console.error('Delete exhibition error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Не вдалося видалити виставку.' });
   }
 });
 

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Адмін панель</title>
+    <link
+      rel="preconnect"
+      href="https://fonts.googleapis.com"
+    />
+    <link
+      rel="preconnect"
+      href="https://fonts.gstatic.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./styles/admin.css" />
+  </head>
+  <body>
+    <main class="admin-page">
+      <section class="card" id="login-section">
+        <h1 class="card__title">Вхід для адміністратора</h1>
+        <form class="form" id="admin-login-form">
+          <label class="form__label">
+            <span class="form__label-text">Електронна пошта</span>
+            <input
+              class="form__input"
+              type="email"
+              name="email"
+              id="admin-email"
+              required
+              autocomplete="username"
+            />
+          </label>
+          <label class="form__label">
+            <span class="form__label-text">Пароль</span>
+            <input
+              class="form__input"
+              type="password"
+              name="password"
+              id="admin-password"
+              required
+              autocomplete="current-password"
+            />
+          </label>
+          <button class="button" type="submit">Увійти</button>
+          <p class="form__hint">
+            Акаунти адміністраторів створюються вручну у базі даних.
+          </p>
+        </form>
+      </section>
+
+      <section class="panel" id="admin-section" hidden>
+        <header class="panel__header">
+          <div>
+            <h1 class="panel__title">Адмін панель</h1>
+            <p class="panel__subtitle" id="admin-name"></p>
+          </div>
+          <button class="button button--light" id="admin-logout" type="button">
+            Вийти
+          </button>
+        </header>
+
+        <section class="panel__card">
+          <h2 class="panel__card-title" id="form-title">Створити нову виставку</h2>
+          <form class="form" id="exhibition-form">
+            <div class="form__row">
+              <label class="form__label">
+                <span class="form__label-text">Назва</span>
+                <input class="form__input" type="text" id="exhibition-name" required />
+              </label>
+              <label class="form__label">
+                <span class="form__label-text">Зображення (URL)</span>
+                <input class="form__input" type="url" id="exhibition-image" placeholder="https://" />
+              </label>
+            </div>
+            <div class="form__row">
+              <label class="form__label">
+                <span class="form__label-text">Дата початку</span>
+                <input class="form__input" type="date" id="exhibition-start" required />
+              </label>
+              <label class="form__label">
+                <span class="form__label-text">Дата завершення</span>
+                <input class="form__input" type="date" id="exhibition-end" required />
+              </label>
+              <label class="form__label">
+                <span class="form__label-text">Вільні місця</span>
+                <input class="form__input" type="number" id="exhibition-seats" min="0" required />
+              </label>
+            </div>
+            <div class="form__actions">
+              <button class="button" type="submit" id="form-submit">Зберегти</button>
+              <button class="button button--light" type="button" id="cancel-edit" hidden>
+                Скасувати
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <section class="panel__card">
+          <h2 class="panel__card-title">Розклад виставок</h2>
+          <div class="table-wrapper">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Назва</th>
+                  <th>Початок</th>
+                  <th>Завершення</th>
+                  <th>Вільні місця</th>
+                  <th>Адміністратор</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody id="exhibitions-table-body"></tbody>
+            </table>
+          </div>
+        </section>
+      </section>
+
+      <div class="notification" id="notification" role="status" aria-live="polite"></div>
+    </main>
+
+    <script src="./scripts/admin.js" defer></script>
+  </body>
+</html>

--- a/frontend/scripts/admin.js
+++ b/frontend/scripts/admin.js
@@ -1,0 +1,343 @@
+const loginSection = document.getElementById('login-section');
+const adminSection = document.getElementById('admin-section');
+const loginForm = document.getElementById('admin-login-form');
+const logoutButton = document.getElementById('admin-logout');
+const notificationElement = document.getElementById('notification');
+const adminNameElement = document.getElementById('admin-name');
+
+const exhibitionForm = document.getElementById('exhibition-form');
+const formTitleElement = document.getElementById('form-title');
+const formSubmitButton = document.getElementById('form-submit');
+const cancelEditButton = document.getElementById('cancel-edit');
+const exhibitionsTableBody = document.getElementById('exhibitions-table-body');
+
+const exhibitionNameInput = document.getElementById('exhibition-name');
+const exhibitionImageInput = document.getElementById('exhibition-image');
+const exhibitionStartInput = document.getElementById('exhibition-start');
+const exhibitionEndInput = document.getElementById('exhibition-end');
+const exhibitionSeatsInput = document.getElementById('exhibition-seats');
+
+let currentAdmin = null;
+let editingExhibitionId = null;
+
+function showNotification(message, duration = 2500) {
+  if (!notificationElement) {
+    return;
+  }
+
+  notificationElement.textContent = message;
+  notificationElement.classList.add('notification--visible');
+
+  setTimeout(() => {
+    notificationElement.classList.remove('notification--visible');
+  }, duration);
+}
+
+function saveAdmin(admin) {
+  currentAdmin = admin;
+  localStorage.setItem('museumAdmin', JSON.stringify(admin));
+}
+
+function clearAdmin() {
+  currentAdmin = null;
+  localStorage.removeItem('museumAdmin');
+}
+
+function loadAdminFromStorage() {
+  const stored = localStorage.getItem('museumAdmin');
+
+  if (!stored) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(stored);
+
+    if (parsed && parsed.id) {
+      currentAdmin = parsed;
+      return parsed;
+    }
+  } catch (error) {
+    console.error('Unable to parse stored admin', error);
+    localStorage.removeItem('museumAdmin');
+  }
+
+  return null;
+}
+
+function updateLayout() {
+  if (currentAdmin) {
+    loginSection.hidden = true;
+    adminSection.hidden = false;
+    adminNameElement.textContent = `${currentAdmin.firstName} ${currentAdmin.lastName}`;
+    loadExhibitions();
+  } else {
+    loginSection.hidden = false;
+    adminSection.hidden = true;
+    adminNameElement.textContent = '';
+    exhibitionsTableBody.innerHTML = '';
+  }
+}
+
+function getAdminHeaders() {
+  if (!currentAdmin) {
+    return {};
+  }
+
+  return {
+    'Content-Type': 'application/json',
+    'X-Admin-Id': currentAdmin.id,
+  };
+}
+
+async function request(url, options = {}) {
+  const config = {
+    ...options,
+    headers: {
+      ...getAdminHeaders(),
+      ...(options.headers || {}),
+    },
+  };
+
+  const response = await fetch(url, config);
+
+  if (!response.ok) {
+    let errorMessage = 'Сталася помилка. Спробуйте ще раз.';
+
+    try {
+      const payload = await response.json();
+      if (payload && payload.error) {
+        errorMessage = payload.error;
+      }
+    } catch (error) {
+      // ignore parsing errors
+    }
+
+    throw new Error(errorMessage);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+async function loadExhibitions() {
+  if (!currentAdmin) {
+    return;
+  }
+
+  try {
+    const data = await request('/api/admin/exhibitions', {
+      method: 'GET',
+      headers: getAdminHeaders(),
+    });
+
+    renderExhibitions(data.exhibitions || []);
+  } catch (error) {
+    showNotification(error.message || 'Не вдалося отримати список виставок.');
+  }
+}
+
+function renderExhibitions(exhibitions) {
+  exhibitionsTableBody.innerHTML = '';
+
+  if (!exhibitions.length) {
+    const emptyRow = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 7;
+    cell.textContent = 'Виставок поки немає.';
+    emptyRow.appendChild(cell);
+    exhibitionsTableBody.appendChild(emptyRow);
+    return;
+  }
+
+  exhibitions.forEach((exhibition) => {
+    const row = document.createElement('tr');
+
+    row.innerHTML = `
+      <td>${exhibition.id}</td>
+      <td>${exhibition.name}</td>
+      <td>${exhibition.startDate}</td>
+      <td>${exhibition.endDate}</td>
+      <td>${exhibition.availableSeats}</td>
+      <td>${exhibition.adminName || '—'}</td>
+      <td></td>
+    `;
+
+    const actionsCell = row.lastElementChild;
+    actionsCell.classList.add('table__actions');
+
+    const editButton = document.createElement('button');
+    editButton.type = 'button';
+    editButton.className = 'button button--light';
+    editButton.textContent = 'Редагувати';
+    editButton.addEventListener('click', () => startEdit(exhibition));
+
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.className = 'button';
+    deleteButton.textContent = 'Видалити';
+    deleteButton.addEventListener('click', () => deleteExhibition(exhibition.id));
+
+    actionsCell.appendChild(editButton);
+    actionsCell.appendChild(deleteButton);
+
+    exhibitionsTableBody.appendChild(row);
+  });
+}
+
+function resetForm() {
+  exhibitionForm.reset();
+  editingExhibitionId = null;
+  formTitleElement.textContent = 'Створити нову виставку';
+  formSubmitButton.textContent = 'Зберегти';
+  cancelEditButton.hidden = true;
+}
+
+function fillForm(exhibition) {
+  exhibitionNameInput.value = exhibition.name || '';
+  exhibitionImageInput.value = exhibition.imageUrl || '';
+  exhibitionStartInput.value = exhibition.startDate || '';
+  exhibitionEndInput.value = exhibition.endDate || '';
+  exhibitionSeatsInput.value = exhibition.availableSeats ?? '';
+}
+
+function startEdit(exhibition) {
+  editingExhibitionId = exhibition.id;
+  formTitleElement.textContent = `Редагувати виставку #${exhibition.id}`;
+  formSubmitButton.textContent = 'Оновити';
+  cancelEditButton.hidden = false;
+  fillForm(exhibition);
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+async function deleteExhibition(id) {
+  if (!currentAdmin) {
+    return;
+  }
+
+  const confirmed = window.confirm('Видалити цю виставку?');
+
+  if (!confirmed) {
+    return;
+  }
+
+  try {
+    await request(`/api/admin/exhibitions/${id}`, {
+      method: 'DELETE',
+      headers: getAdminHeaders(),
+    });
+
+    showNotification('Виставку видалено.');
+    loadExhibitions();
+    if (editingExhibitionId === id) {
+      resetForm();
+    }
+  } catch (error) {
+    showNotification(error.message || 'Не вдалося видалити виставку.');
+  }
+}
+
+if (loginForm) {
+  loginForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const email = event.target.email.value.trim();
+    const password = event.target.password.value;
+
+    if (!email || !password) {
+      showNotification('Заповніть електронну пошту та пароль.');
+      return;
+    }
+
+    loginForm.querySelector('button[type="submit"]').disabled = true;
+
+    try {
+      const data = await request('/api/admin/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+
+      saveAdmin(data.admin);
+      showNotification('Вітаємо! Ви увійшли як адміністратор.');
+      updateLayout();
+    } catch (error) {
+      showNotification(error.message || 'Не вдалося увійти.');
+    } finally {
+      loginForm.querySelector('button[type="submit"]').disabled = false;
+    }
+  });
+}
+
+if (logoutButton) {
+  logoutButton.addEventListener('click', () => {
+    clearAdmin();
+    resetForm();
+    updateLayout();
+  });
+}
+
+if (cancelEditButton) {
+  cancelEditButton.addEventListener('click', () => {
+    resetForm();
+  });
+}
+
+if (exhibitionForm) {
+  exhibitionForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    if (!currentAdmin) {
+      showNotification('Спочатку увійдіть як адміністратор.');
+      return;
+    }
+
+    const payload = {
+      name: exhibitionNameInput.value.trim(),
+      imageUrl: exhibitionImageInput.value.trim() || null,
+      startDate: exhibitionStartInput.value,
+      endDate: exhibitionEndInput.value,
+      availableSeats: Number(exhibitionSeatsInput.value),
+    };
+
+    if (!payload.name || !payload.startDate || !payload.endDate) {
+      showNotification('Будь ласка, заповніть усі обов\'язкові поля.');
+      return;
+    }
+
+    if (!Number.isFinite(payload.availableSeats)) {
+      showNotification('Вкажіть коректну кількість місць.');
+      return;
+    }
+
+    formSubmitButton.disabled = true;
+
+    try {
+      if (editingExhibitionId) {
+        await request(`/api/admin/exhibitions/${editingExhibitionId}`, {
+          method: 'PUT',
+          body: JSON.stringify(payload),
+        });
+        showNotification('Виставку оновлено.');
+      } else {
+        await request('/api/admin/exhibitions', {
+          method: 'POST',
+          body: JSON.stringify(payload),
+        });
+        showNotification('Виставку створено.');
+      }
+
+      resetForm();
+      loadExhibitions();
+    } catch (error) {
+      showNotification(error.message || 'Не вдалося зберегти виставку.');
+    } finally {
+      formSubmitButton.disabled = false;
+    }
+  });
+}
+
+loadAdminFromStorage();
+updateLayout();

--- a/frontend/styles/admin.css
+++ b/frontend/styles/admin.css
@@ -1,0 +1,226 @@
+:root {
+  font-family: 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #1f1f1f;
+  background-color: #f5f5f7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: #f5f5f7;
+}
+
+.admin-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 16px 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card,
+.panel {
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.12);
+  padding: 32px;
+}
+
+.card__title {
+  margin: 0 0 24px;
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.form__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.form__label {
+  flex: 1 1 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form__label-text {
+  font-size: 14px;
+  font-weight: 500;
+  color: #4b5563;
+}
+
+.form__input {
+  padding: 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 16px;
+  transition: border-color 0.2s ease;
+}
+
+.form__input:focus {
+  border-color: #2563eb;
+  outline: none;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 20px;
+  border-radius: 8px;
+  background-color: #2563eb;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.button:hover {
+  background-color: #1d4ed8;
+}
+
+.button:disabled {
+  background-color: #93c5fd;
+  cursor: not-allowed;
+}
+
+.button--light {
+  background-color: #e5e7eb;
+  color: #1f2937;
+}
+
+.button--light:hover {
+  background-color: #d1d5db;
+}
+
+.form__hint {
+  margin: 0;
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.form__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.panel__title {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 600;
+}
+
+.panel__subtitle {
+  margin: 4px 0 0;
+  font-size: 16px;
+  color: #4b5563;
+}
+
+.panel__card {
+  background-color: #f9fafb;
+  border-radius: 12px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.panel__card-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 600px;
+}
+
+.table th,
+.table td {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid #e5e7eb;
+  font-size: 15px;
+}
+
+.table th {
+  font-weight: 600;
+  color: #374151;
+  background-color: #f3f4f6;
+}
+
+.table__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.notification {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  padding: 12px 20px;
+  background-color: #2563eb;
+  color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.3);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(20px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.notification--visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+@media (max-width: 768px) {
+  .admin-page {
+    padding: 24px 12px 48px;
+  }
+
+  .card,
+  .panel {
+    padding: 24px;
+  }
+
+  .panel__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .form__row {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add admin authentication endpoints and CRUD APIs for exhibitions
- build standalone admin panel page with login, schedule table, and create/edit form
- style and script the admin dashboard for simple management workflows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690689fd77948331a35ac12e67c9389e