### PR TITLE
Add admin admin panel and exhibition management

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -24,6 +24,57 @@ function mapUser(dbRow) {
   };
 }
 
+function mapExhibition(dbRow) {
+  if (!dbRow) {
+    return null;
+  }
+
+  const availableSeats = Number(dbRow.available_seats);
+  const adminId = Number(dbRow.admin_id);
+
+  const exhibition = {
+    id: dbRow.id,
+    name: dbRow.name,
+    imageUrl: dbRow.image_url,
+    startDate: dbRow.start_date,
+    endDate: dbRow.end_date,
+    availableSeats: Number.isNaN(availableSeats)
+      ? dbRow.available_seats
+      : availableSeats,
+    adminId: Number.isNaN(adminId) ? dbRow.admin_id : adminId,
+  };
+
+  if (dbRow.admin_name) {
+    exhibition.adminName = dbRow.admin_name;
+  }
+
+  return exhibition;
+}
+
+function isValidDate(value) {
+  if (!value) {
+    return false;
+  }
+
+  const parsed = new Date(value);
+  return !Number.isNaN(parsed.getTime());
+}
+
+async function findAdminById(adminId) {
+  const id = Number(adminId);
+
+  if (!Number.isInteger(id) || id <= 0) {
+    return null;
+  }
+
+  const [rows] = await pool.execute(
+    `SELECT id, first_name, last_name FROM Admins WHERE id = ?`,
+    [id]
+  );
+
+  return rows[0] || null;
+}
+
 function normalizePhone(phone) {
   if (!phone) {
     return null;
@@ -143,6 +194,360 @@ app.post('/api/login', async (req, res) => {
     return res
       .status(500)
       .json({ error: 'Сталася помилка під час авторизації.' });
+  }
+});
+
+app.post('/api/admin/login', async (req, res) => {
+  const { email, password } = req.body || {};
+
+  if (!email || !password) {
+    return res
+      .status(400)
+      .json({ error: 'Необхідно вказати електронну пошту та пароль.' });
+  }
+
+  try {
+    const normalizedEmail = email.trim().toLowerCase();
+
+    const [rows] = await pool.execute(
+      `SELECT id, first_name, last_name, email, password
+         FROM Admins
+        WHERE LOWER(email) = ?`,
+      [normalizedEmail]
+    );
+
+    if (!rows.length) {
+      return res
+        .status(401)
+        .json({ error: 'Невірна електронна пошта або пароль.' });
+    }
+
+    const admin = rows[0];
+
+    let passwordsMatch = false;
+
+    try {
+      passwordsMatch = await bcrypt.compare(password, admin.password);
+    } catch (compareError) {
+      console.warn('Admin password compare warning:', compareError);
+    }
+
+    if (!passwordsMatch && admin.password === password) {
+      passwordsMatch = true;
+    }
+
+    if (!passwordsMatch) {
+      return res
+        .status(401)
+        .json({ error: 'Невірна електронна пошта або пароль.' });
+    }
+
+    return res.json({
+      admin: {
+        id: admin.id,
+        firstName: admin.first_name,
+        lastName: admin.last_name,
+        email: admin.email,
+      },
+    });
+  } catch (error) {
+    console.error('Admin login error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Сталася помилка під час авторизації адміністратора.' });
+  }
+});
+
+app.get('/api/admin/exhibitions', async (req, res) => {
+  const adminId = Number(req.query.adminId);
+
+  if (!Number.isInteger(adminId) || adminId <= 0) {
+    return res
+      .status(400)
+      .json({ error: 'Не вказано адміністратора.' });
+  }
+
+  try {
+    const admin = await findAdminById(adminId);
+
+    if (!admin) {
+      return res.status(403).json({ error: 'Адміністратора не знайдено.' });
+    }
+
+    const [rows] = await pool.execute(
+      `SELECT e.id,
+              e.name,
+              e.image_url,
+              e.start_date,
+              e.end_date,
+              e.available_seats,
+              e.admin_id,
+              CONCAT(a.first_name, ' ', a.last_name) AS admin_name
+         FROM Exhibitions e
+         JOIN Admins a ON e.admin_id = a.id
+        ORDER BY e.start_date, e.end_date, e.name`,
+      []
+    );
+
+    const exhibitions = rows.map(mapExhibition);
+    return res.json({ exhibitions });
+  } catch (error) {
+    console.error('Admin exhibitions fetch error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Не вдалося отримати список виставок.' });
+  }
+});
+
+app.post('/api/admin/exhibitions', async (req, res) => {
+  const {
+    adminId,
+    name,
+    imageUrl = null,
+    startDate,
+    endDate,
+    availableSeats,
+  } = req.body || {};
+
+  const trimmedName = typeof name === 'string' ? name.trim() : '';
+  const normalizedImageUrl =
+    typeof imageUrl === 'string' && imageUrl.trim() ? imageUrl.trim() : null;
+  const numericAdminId = Number(adminId);
+
+  if (!Number.isInteger(numericAdminId) || numericAdminId <= 0) {
+    return res
+      .status(400)
+      .json({ error: 'Некоректний ідентифікатор адміністратора.' });
+  }
+
+  if (!trimmedName || !startDate || !endDate) {
+    return res
+      .status(400)
+      .json({ error: 'Будь ласка, заповніть усі обов\'язкові поля.' });
+  }
+
+  const seats = Number(availableSeats);
+
+  if (!Number.isInteger(seats) || seats < 0) {
+    return res
+      .status(400)
+      .json({ error: 'Кількість місць має бути невід\'ємним цілим числом.' });
+  }
+
+  if (!isValidDate(startDate) || !isValidDate(endDate)) {
+    return res
+      .status(400)
+      .json({ error: 'Некоректний формат дати.' });
+  }
+
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  if (start > end) {
+    return res
+      .status(400)
+      .json({ error: 'Дата початку не може бути пізніше дати завершення.' });
+  }
+
+  try {
+    const admin = await findAdminById(numericAdminId);
+
+    if (!admin) {
+      return res.status(403).json({ error: 'Адміністратора не знайдено.' });
+    }
+
+    const [result] = await pool.execute(
+      `INSERT INTO Exhibitions (name, image_url, start_date, end_date, available_seats, admin_id)
+       VALUES (?, ?, ?, ?, ?, ?)`
+        .replace(/\s+/g, ' '),
+      [trimmedName, normalizedImageUrl, startDate, endDate, seats, numericAdminId]
+    );
+
+    const [rows] = await pool.execute(
+      `SELECT e.id,
+              e.name,
+              e.image_url,
+              e.start_date,
+              e.end_date,
+              e.available_seats,
+              e.admin_id,
+              CONCAT(a.first_name, ' ', a.last_name) AS admin_name
+         FROM Exhibitions e
+         JOIN Admins a ON e.admin_id = a.id
+        WHERE e.id = ?`,
+      [result.insertId]
+    );
+
+    return res.status(201).json({ exhibition: mapExhibition(rows[0]) });
+  } catch (error) {
+    console.error('Admin exhibition create error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Не вдалося створити виставку.' });
+  }
+});
+
+app.put('/api/admin/exhibitions/:id', async (req, res) => {
+  const exhibitionId = Number(req.params.id);
+
+  if (!Number.isInteger(exhibitionId) || exhibitionId <= 0) {
+    return res.status(400).json({ error: 'Некоректний ідентифікатор виставки.' });
+  }
+
+  const {
+    adminId,
+    name,
+    imageUrl = null,
+    startDate,
+    endDate,
+    availableSeats,
+  } = req.body || {};
+
+  const trimmedName = typeof name === 'string' ? name.trim() : '';
+  const normalizedImageUrl =
+    typeof imageUrl === 'string' && imageUrl.trim() ? imageUrl.trim() : null;
+  const numericAdminId = Number(adminId);
+
+  if (!Number.isInteger(numericAdminId) || numericAdminId <= 0) {
+    return res
+      .status(400)
+      .json({ error: 'Некоректний ідентифікатор адміністратора.' });
+  }
+
+  if (!trimmedName || !startDate || !endDate) {
+    return res
+      .status(400)
+      .json({ error: 'Будь ласка, заповніть усі обов\'язкові поля.' });
+  }
+
+  const seats = Number(availableSeats);
+
+  if (!Number.isInteger(seats) || seats < 0) {
+    return res
+      .status(400)
+      .json({ error: 'Кількість місць має бути невід\'ємним цілим числом.' });
+  }
+
+  if (!isValidDate(startDate) || !isValidDate(endDate)) {
+    return res
+      .status(400)
+      .json({ error: 'Некоректний формат дати.' });
+  }
+
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  if (start > end) {
+    return res
+      .status(400)
+      .json({ error: 'Дата початку не може бути пізніше дати завершення.' });
+  }
+
+  try {
+    const admin = await findAdminById(numericAdminId);
+
+    if (!admin) {
+      return res.status(403).json({ error: 'Адміністратора не знайдено.' });
+    }
+
+    const [existingRows] = await pool.execute(
+      `SELECT id, admin_id FROM Exhibitions WHERE id = ?`,
+      [exhibitionId]
+    );
+
+    if (!existingRows.length) {
+      return res.status(404).json({ error: 'Виставку не знайдено.' });
+    }
+
+    const exhibitionAdminId = Number(existingRows[0].admin_id);
+
+    if (Number.isNaN(exhibitionAdminId) || exhibitionAdminId !== numericAdminId) {
+      return res
+        .status(403)
+        .json({ error: 'Немає прав для редагування цієї виставки.' });
+    }
+
+    await pool.execute(
+      `UPDATE Exhibitions
+          SET name = ?,
+              image_url = ?,
+              start_date = ?,
+              end_date = ?,
+              available_seats = ?
+        WHERE id = ?`
+        .replace(/\s+/g, ' '),
+      [trimmedName, normalizedImageUrl, startDate, endDate, seats, exhibitionId]
+    );
+
+    const [rows] = await pool.execute(
+      `SELECT e.id,
+              e.name,
+              e.image_url,
+              e.start_date,
+              e.end_date,
+              e.available_seats,
+              e.admin_id,
+              CONCAT(a.first_name, ' ', a.last_name) AS admin_name
+         FROM Exhibitions e
+         JOIN Admins a ON e.admin_id = a.id
+        WHERE e.id = ?`,
+      [exhibitionId]
+    );
+
+    return res.json({ exhibition: mapExhibition(rows[0]) });
+  } catch (error) {
+    console.error('Admin exhibition update error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Не вдалося оновити виставку.' });
+  }
+});
+
+app.delete('/api/admin/exhibitions/:id', async (req, res) => {
+  const exhibitionId = Number(req.params.id);
+  const adminId = Number(req.query.adminId);
+
+  if (
+    !Number.isInteger(exhibitionId) ||
+    exhibitionId <= 0 ||
+    !Number.isInteger(adminId) ||
+    adminId <= 0
+  ) {
+    return res.status(400).json({ error: 'Не вказано виставку або адміністратора.' });
+  }
+
+  try {
+    const admin = await findAdminById(adminId);
+
+    if (!admin) {
+      return res.status(403).json({ error: 'Адміністратора не знайдено.' });
+    }
+
+    const [existingRows] = await pool.execute(
+      `SELECT id, admin_id FROM Exhibitions WHERE id = ?`,
+      [exhibitionId]
+    );
+
+    if (!existingRows.length) {
+      return res.status(404).json({ error: 'Виставку не знайдено.' });
+    }
+
+    const exhibitionAdminId = Number(existingRows[0].admin_id);
+
+    if (Number.isNaN(exhibitionAdminId) || exhibitionAdminId !== adminId) {
+      return res
+        .status(403)
+        .json({ error: 'Немає прав для видалення цієї виставки.' });
+    }
+
+    await pool.execute(`DELETE FROM Exhibitions WHERE id = ?`, [exhibitionId]);
+
+    return res.status(204).send();
+  } catch (error) {
+    console.error('Admin exhibition delete error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Не вдалося видалити виставку.' });
   }
 });
 

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -117,6 +117,17 @@
         color: #1d1f22;
       }
 
+      .input-error {
+        border-color: #c62828;
+        background-color: #fdecea;
+      }
+
+      .field-error {
+        color: #c62828;
+        font-size: 0.875rem;
+        margin: 0;
+      }
+
       table {
         width: 100%;
         border-collapse: collapse;
@@ -217,33 +228,84 @@
 
       <section id="managementSection" class="hidden">
         <h2>Керування виставками</h2>
-        <form id="exhibitionForm">
-          <input type="hidden" id="exhibitionId" />
-          <label>
-            Назва виставки
-            <input type="text" id="exhibitionName" name="name" required />
-          </label>
-          <label>
-            Посилання на зображення (опційно)
-            <input type="url" id="exhibitionImage" name="imageUrl" placeholder="https://" />
-          </label>
-          <label>
-            Дата початку
-            <input type="date" id="exhibitionStart" name="startDate" required />
-          </label>
-          <label>
-            Дата завершення
-            <input type="date" id="exhibitionEnd" name="endDate" required />
-          </label>
-          <label>
-            Доступні місця
-            <input type="number" id="exhibitionSeats" name="availableSeats" min="0" step="1" required />
-          </label>
-          <div class="form-actions">
-            <button type="submit">Зберегти</button>
-            <button type="button" id="resetFormButton" class="secondary-button">Очистити форму</button>
-          </div>
-        </form>
+        <div id="exhibitionApp">
+          <form @submit.prevent="handleSubmit">
+            <label>
+              Назва виставки
+              <input
+                v-model.trim="form.name"
+                :class="{ 'input-error': nameErrorVisible }"
+                type="text"
+                name="name"
+                required
+                @blur="markTouched('name')"
+              />
+              <p v-if="nameErrorVisible" class="field-error">{{ errors.name }}</p>
+            </label>
+            <label>
+              Посилання на зображення (опційно)
+              <input
+                v-model.trim="form.imageUrl"
+                :class="{ 'input-error': imageErrorVisible }"
+                type="url"
+                name="imageUrl"
+                placeholder="https://"
+                @blur="markTouched('imageUrl')"
+              />
+              <p v-if="imageErrorVisible" class="field-error">{{ errors.imageUrl }}</p>
+            </label>
+            <label>
+              Дата початку
+              <input
+                v-model="form.startDate"
+                :class="{ 'input-error': startDateErrorVisible }"
+                type="date"
+                name="startDate"
+                required
+                @blur="markTouched('startDate')"
+              />
+              <p v-if="startDateErrorVisible" class="field-error">{{ errors.startDate }}</p>
+            </label>
+            <label>
+              Дата завершення
+              <input
+                v-model="form.endDate"
+                :class="{ 'input-error': endDateErrorVisible }"
+                type="date"
+                name="endDate"
+                required
+                @blur="markTouched('endDate')"
+              />
+              <p v-if="endDateErrorVisible" class="field-error">{{ errors.endDate }}</p>
+            </label>
+            <label>
+              Доступні місця
+              <input
+                v-model.trim="form.availableSeats"
+                :class="{ 'input-error': seatsErrorVisible }"
+                type="number"
+                name="availableSeats"
+                min="0"
+                step="1"
+                required
+                @blur="markTouched('availableSeats')"
+              />
+              <p v-if="seatsErrorVisible" class="field-error">{{ errors.availableSeats }}</p>
+            </label>
+            <div class="form-actions">
+              <button type="submit" :disabled="isSubmitting">{{ submitLabel }}</button>
+              <button
+                type="button"
+                id="resetFormButton"
+                class="secondary-button"
+                :disabled="isSubmitting"
+                @click="resetForm()"
+              >
+                Очистити форму
+              </button>
+            </div>
+          </form>
+        </div>
       </section>
 
       <section id="scheduleSection" class="hidden">
@@ -263,6 +325,7 @@
       </section>
     </main>
 
+    <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
     <script src="./scripts/admin.js" defer></script>
   </body>
 </html>

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -119,7 +119,8 @@
 
       .input-error {
         border-color: #c62828;
-        background-color: #fdecea;
+        /* background-color: #fdecea; */
+        box-shadow: 0 0 0 3px rgba(211, 47, 47, 0.12);
       }
 
       .field-error {

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,0 +1,268 @@
+<!doctype html>
+<html lang="uk">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Адмін-панель — NAMU</title>
+    <link rel="icon" type="image/x-icon" href="./images/NAMU_logo.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;600&family=Montserrat:wght@500;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: 'IBM Plex Sans', 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
+
+      body {
+        margin: 0;
+        background-color: #f5f5f5;
+        color: #1d1f22;
+      }
+
+      header {
+        background-color: #1d1f22;
+        color: #fff;
+        padding: 1.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: 1.5rem;
+      }
+
+      header button {
+        border: none;
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        cursor: pointer;
+        background-color: #fff;
+        color: #1d1f22;
+        font-weight: 600;
+      }
+
+      main {
+        padding: 2rem 1rem 4rem;
+        max-width: 960px;
+        margin: 0 auto;
+      }
+
+      section {
+        background-color: #fff;
+        border-radius: 12px;
+        padding: 1.5rem;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+        margin-bottom: 1.5rem;
+      }
+
+      h2 {
+        margin-top: 0;
+        margin-bottom: 1rem;
+        font-size: 1.25rem;
+      }
+
+      form {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .form-actions {
+        display: flex;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      label {
+        display: grid;
+        gap: 0.5rem;
+      }
+
+      input,
+      textarea,
+      select {
+        padding: 0.75rem;
+        border: 1px solid #cfd1d6;
+        border-radius: 6px;
+        font-size: 1rem;
+        font-family: inherit;
+      }
+
+      button[type='submit'],
+      .table-button {
+        background-color: #1d1f22;
+        color: #fff;
+        border: none;
+        padding: 0.75rem 1.25rem;
+        border-radius: 6px;
+        cursor: pointer;
+        font-weight: 600;
+        transition: opacity 0.2s ease;
+      }
+
+      button[type='submit']:hover,
+      .table-button:hover,
+      header button:hover,
+      .secondary-button:hover {
+        opacity: 0.85;
+      }
+
+      .secondary-button {
+        background-color: #e0e3e7;
+        color: #1d1f22;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.95rem;
+      }
+
+      thead {
+        background-color: #f0f0f0;
+      }
+
+      th,
+      td {
+        padding: 0.75rem;
+        border-bottom: 1px solid #e2e4e9;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      tbody tr:last-child td {
+        border-bottom: none;
+      }
+
+      .table-actions {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+
+      .table-button.delete {
+        background-color: #c62828;
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      @media (max-width: 720px) {
+        table,
+        thead,
+        tbody,
+        th,
+        td,
+        tr {
+          display: block;
+        }
+
+        thead {
+          display: none;
+        }
+
+        tr {
+          border: 1px solid #e2e4e9;
+          border-radius: 8px;
+          margin-bottom: 1rem;
+          padding: 0.5rem 0.75rem;
+          background-color: #fff;
+        }
+
+        td {
+          border: none;
+          padding: 0.5rem 0;
+        }
+
+        td::before {
+          content: attr(data-label);
+          display: block;
+          font-weight: 600;
+          margin-bottom: 0.25rem;
+          color: #6b6f76;
+        }
+
+        .table-actions {
+          justify-content: flex-start;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Адмін-панель музею</h1>
+      <button id="logoutButton" class="hidden" type="button">Вийти</button>
+    </header>
+    <main>
+      <section id="loginSection">
+        <h2>Вхід для адміністраторів</h2>
+        <form id="adminLoginForm">
+          <label>
+            Електронна пошта
+            <input type="email" id="adminEmail" name="email" required autocomplete="email" />
+          </label>
+          <label>
+            Пароль
+            <input type="password" id="adminPassword" name="password" required autocomplete="current-password" />
+          </label>
+          <button type="submit">Увійти</button>
+        </form>
+      </section>
+
+      <section id="managementSection" class="hidden">
+        <h2>Керування виставками</h2>
+        <form id="exhibitionForm">
+          <input type="hidden" id="exhibitionId" />
+          <label>
+            Назва виставки
+            <input type="text" id="exhibitionName" name="name" required />
+          </label>
+          <label>
+            Посилання на зображення (опційно)
+            <input type="url" id="exhibitionImage" name="imageUrl" placeholder="https://" />
+          </label>
+          <label>
+            Дата початку
+            <input type="date" id="exhibitionStart" name="startDate" required />
+          </label>
+          <label>
+            Дата завершення
+            <input type="date" id="exhibitionEnd" name="endDate" required />
+          </label>
+          <label>
+            Доступні місця
+            <input type="number" id="exhibitionSeats" name="availableSeats" min="0" step="1" required />
+          </label>
+          <div class="form-actions">
+            <button type="submit">Зберегти</button>
+            <button type="button" id="resetFormButton" class="secondary-button">Очистити форму</button>
+          </div>
+        </form>
+      </section>
+
+      <section id="scheduleSection" class="hidden">
+        <h2>Графік виставок</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Назва</th>
+              <th>Період</th>
+              <th>Вільні місця</th>
+              <th>Адміністратор</th>
+              <th>Дії</th>
+            </tr>
+          </thead>
+          <tbody id="exhibitionsTableBody"></tbody>
+        </table>
+      </section>
+    </main>
+
+    <script src="./scripts/admin.js" defer></script>
+  </body>
+</html>

--- a/frontend/scripts/admin.js
+++ b/frontend/scripts/admin.js
@@ -19,8 +19,27 @@ function saveAdmin(admin) {
   localStorage.setItem(ADMIN_KEY, JSON.stringify(admin));
 }
 
+function formatDatePart(value) {
+  if (!value) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value.replace(/-/g, '.');
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    const year = value.getFullYear();
+    const month = String(value.getMonth() + 1).padStart(2, '0');
+    const day = String(value.getDate()).padStart(2, '0');
+    return `${year}.${month}.${day}`;
+  }
+
+  return String(value);
+}
+
 function formatDateRange(startDate, endDate) {
-  return `${startDate} — ${endDate}`;
+  return `${formatDatePart(startDate)} — ${formatDatePart(endDate)}`;
 }
 
 function renderTable(exhibitions) {

--- a/frontend/scripts/admin.js
+++ b/frontend/scripts/admin.js
@@ -1,0 +1,344 @@
+const ADMIN_KEY = 'museumAdmin';
+
+function readAdmin() {
+  try {
+    const raw = localStorage.getItem(ADMIN_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch (error) {
+    console.error('Failed to read admin data:', error);
+    return null;
+  }
+}
+
+function saveAdmin(admin) {
+  if (!admin) {
+    localStorage.removeItem(ADMIN_KEY);
+    return;
+  }
+
+  localStorage.setItem(ADMIN_KEY, JSON.stringify(admin));
+}
+
+function formatDateRange(startDate, endDate) {
+  return `${startDate} — ${endDate}`;
+}
+
+function renderTable(exhibitions) {
+  const tbody = document.getElementById('exhibitionsTableBody');
+
+  if (!tbody) {
+    return;
+  }
+
+  tbody.innerHTML = '';
+
+  if (!exhibitions.length) {
+    const emptyRow = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 5;
+    cell.textContent = 'Наразі немає створених виставок.';
+    emptyRow.appendChild(cell);
+    tbody.appendChild(emptyRow);
+    return;
+  }
+
+  exhibitions.forEach((exhibition) => {
+    const row = document.createElement('tr');
+
+    const nameCell = document.createElement('td');
+    nameCell.dataset.label = 'Назва';
+    nameCell.textContent = exhibition.name;
+    row.appendChild(nameCell);
+
+    const periodCell = document.createElement('td');
+    periodCell.dataset.label = 'Період';
+    periodCell.textContent = formatDateRange(
+      exhibition.startDate,
+      exhibition.endDate
+    );
+    row.appendChild(periodCell);
+
+    const seatsCell = document.createElement('td');
+    seatsCell.dataset.label = 'Вільні місця';
+    seatsCell.textContent = String(exhibition.availableSeats);
+    row.appendChild(seatsCell);
+
+    const adminCell = document.createElement('td');
+    adminCell.dataset.label = 'Адміністратор';
+    adminCell.textContent = exhibition.adminName || '—';
+    row.appendChild(adminCell);
+
+    const actionsCell = document.createElement('td');
+    actionsCell.dataset.label = 'Дії';
+    actionsCell.className = 'table-actions';
+
+    const editButton = document.createElement('button');
+    editButton.type = 'button';
+    editButton.className = 'table-button';
+    editButton.textContent = 'Редагувати';
+    editButton.addEventListener('click', () => populateForm(exhibition));
+
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.className = 'table-button delete';
+    deleteButton.textContent = 'Видалити';
+    deleteButton.addEventListener('click', () => handleDelete(exhibition.id));
+
+    actionsCell.appendChild(editButton);
+    actionsCell.appendChild(deleteButton);
+    row.appendChild(actionsCell);
+
+    tbody.appendChild(row);
+  });
+}
+
+function setSubmitButtonText(isEditing) {
+  const button = document.querySelector(
+    '#exhibitionForm button[type="submit"]'
+  );
+
+  if (!button) {
+    return;
+  }
+
+  button.textContent = isEditing ? 'Оновити' : 'Зберегти';
+}
+
+async function fetchExhibitions() {
+  const admin = readAdmin();
+
+  if (!admin) {
+    return [];
+  }
+
+  const response = await fetch(`/api/admin/exhibitions?adminId=${admin.id}`);
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const error = payload.error || 'Не вдалося отримати виставки.';
+    throw new Error(error);
+  }
+
+  return payload.exhibitions || [];
+}
+
+function populateForm(exhibition) {
+  const form = document.getElementById('exhibitionForm');
+
+  if (!form) {
+    return;
+  }
+
+  document.getElementById('exhibitionId').value = exhibition.id;
+  document.getElementById('exhibitionName').value = exhibition.name;
+  document.getElementById('exhibitionImage').value = exhibition.imageUrl || '';
+  document.getElementById('exhibitionStart').value = exhibition.startDate;
+  document.getElementById('exhibitionEnd').value = exhibition.endDate;
+  document.getElementById('exhibitionSeats').value = exhibition.availableSeats;
+  setSubmitButtonText(true);
+}
+
+function resetForm() {
+  const form = document.getElementById('exhibitionForm');
+
+  if (!form) {
+    return;
+  }
+
+  form.reset();
+  document.getElementById('exhibitionId').value = '';
+  setSubmitButtonText(false);
+}
+
+async function handleDelete(exhibitionId) {
+  if (!confirm('Видалити цю виставку?')) {
+    return;
+  }
+
+  const admin = readAdmin();
+
+  if (!admin) {
+    alert('Потрібно авторизуватися.');
+    return;
+  }
+
+  try {
+    const response = await fetch(
+      `/api/admin/exhibitions/${exhibitionId}?adminId=${admin.id}`,
+      {
+        method: 'DELETE',
+      }
+    );
+
+    if (!response.ok && response.status !== 204) {
+      const payload = await response.json().catch(() => ({}));
+      throw new Error(payload.error || 'Не вдалося видалити виставку.');
+    }
+
+    await refreshExhibitions();
+    resetForm();
+  } catch (error) {
+    alert(error.message || 'Не вдалося видалити виставку.');
+  }
+}
+
+async function refreshExhibitions() {
+  try {
+    const exhibitions = await fetchExhibitions();
+    renderTable(exhibitions);
+  } catch (error) {
+    alert(error.message || 'Не вдалося завантажити виставки.');
+  }
+}
+
+function toggleVisibility(isAuthorized) {
+  const loginSection = document.getElementById('loginSection');
+  const managementSection = document.getElementById('managementSection');
+  const scheduleSection = document.getElementById('scheduleSection');
+  const logoutButton = document.getElementById('logoutButton');
+
+  if (isAuthorized) {
+    loginSection.classList.add('hidden');
+    managementSection.classList.remove('hidden');
+    scheduleSection.classList.remove('hidden');
+    logoutButton.classList.remove('hidden');
+  } else {
+    loginSection.classList.remove('hidden');
+    managementSection.classList.add('hidden');
+    scheduleSection.classList.add('hidden');
+    logoutButton.classList.add('hidden');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const loginForm = document.getElementById('adminLoginForm');
+  const exhibitionForm = document.getElementById('exhibitionForm');
+  const logoutButton = document.getElementById('logoutButton');
+  const resetFormButton = document.getElementById('resetFormButton');
+
+  const admin = readAdmin();
+  const isAuthorized = Boolean(admin);
+  toggleVisibility(isAuthorized);
+  setSubmitButtonText(false);
+
+  if (isAuthorized) {
+    refreshExhibitions();
+  }
+
+  if (loginForm) {
+    loginForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+
+      const email = document.getElementById('adminEmail').value.trim();
+      const password = document.getElementById('adminPassword').value.trim();
+
+      if (!email || !password) {
+        alert('Заповніть електронну пошту та пароль.');
+        return;
+      }
+
+      try {
+        const response = await fetch('/api/admin/login', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ email, password }),
+        });
+
+        const payload = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+          throw new Error(payload.error || 'Не вдалося увійти.');
+        }
+
+        if (!payload.admin) {
+          throw new Error('Відповідь сервера некоректна.');
+        }
+
+        saveAdmin(payload.admin);
+        toggleVisibility(true);
+        resetForm();
+        await refreshExhibitions();
+        loginForm.reset();
+      } catch (error) {
+        alert(error.message || 'Не вдалося увійти.');
+      }
+    });
+  }
+
+  if (exhibitionForm) {
+    exhibitionForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+
+      const adminData = readAdmin();
+
+      if (!adminData) {
+        alert('Потрібно авторизуватися.');
+        return;
+      }
+
+      const id = document.getElementById('exhibitionId').value;
+      const name = document.getElementById('exhibitionName').value.trim();
+      const imageUrl = document.getElementById('exhibitionImage').value.trim();
+      const startDate = document.getElementById('exhibitionStart').value;
+      const endDate = document.getElementById('exhibitionEnd').value;
+      const availableSeats = document.getElementById('exhibitionSeats').value;
+
+      if (!name || !startDate || !endDate) {
+        alert('Будь ласка, заповніть усі обов\'язкові поля.');
+        return;
+      }
+
+      const payload = {
+        adminId: adminData.id,
+        name,
+        imageUrl: imageUrl || null,
+        startDate,
+        endDate,
+        availableSeats,
+      };
+
+      const url = id
+        ? `/api/admin/exhibitions/${id}`
+        : '/api/admin/exhibitions';
+
+      const method = id ? 'PUT' : 'POST';
+
+      try {
+        const response = await fetch(url, {
+          method,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        });
+
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+          throw new Error(data.error || 'Не вдалося зберегти виставку.');
+        }
+
+        resetForm();
+        await refreshExhibitions();
+      } catch (error) {
+        alert(error.message || 'Не вдалося зберегти виставку.');
+      }
+    });
+  }
+
+  if (resetFormButton) {
+    resetFormButton.addEventListener('click', () => {
+      resetForm();
+    });
+  }
+
+  if (logoutButton) {
+    logoutButton.addEventListener('click', () => {
+      saveAdmin(null);
+      resetForm();
+      toggleVisibility(false);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add admin authentication and exhibition CRUD endpoints to the Express backend
- create a standalone admin dashboard page with forms for managing exhibitions and viewing the schedule
- implement simple client-side logic for admin login, CRUD actions, and table rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69068d09e14c8331adfba422b0185279