### PR TITLE
Add lightbox preview for exhibition images

### DIFF
--- a/frontend/Exhibitions.html
+++ b/frontend/Exhibitions.html
@@ -11,6 +11,10 @@
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
       rel="stylesheet"
     />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/basiclightbox@5/dist/basicLightbox.min.css"
+    />
     <link rel="stylesheet" href="./styles/main.css" />
   </head>
   <body class="auth-page">
@@ -55,6 +59,7 @@
       </div>
     </div>
 
+    <script src="https://unpkg.com/basiclightbox@5/dist/basicLightbox.min.js"></script>
     <script type="module" src="./scripts/exhibitions.js"></script>
   </body>
 </html>

--- a/frontend/scripts/exhibitions.js
+++ b/frontend/scripts/exhibitions.js
@@ -50,6 +50,26 @@ function formatPeriod(startDate, endDate) {
   return start || end || '—';
 }
 
+function openExhibitionImage({ imageUrl, name }) {
+  if (!imageUrl) {
+    return;
+  }
+
+  const { basicLightbox } = window;
+
+  if (!basicLightbox || typeof basicLightbox.create !== 'function') {
+    return;
+  }
+
+  const lightboxImage = document.createElement('img');
+  lightboxImage.src = imageUrl;
+  lightboxImage.alt = `Зображення виставки ${name || 'без назви'}`;
+  lightboxImage.className = 'exhibitions-lightbox__image';
+
+  const instance = basicLightbox.create(lightboxImage.outerHTML);
+  instance.show();
+}
+
 function renderExhibitions(exhibitions) {
   if (!exhibitionsTableBody) {
     return;
@@ -68,12 +88,25 @@ function renderExhibitions(exhibitions) {
     const imageCell = document.createElement('td');
 
     if (exhibition.imageUrl) {
+      const imageButton = document.createElement('button');
+      imageButton.type = 'button';
+      imageButton.className = 'exhibitions-table__image-button';
+
       const image = document.createElement('img');
       image.src = exhibition.imageUrl;
       image.alt = `Зображення виставки ${exhibition.name || 'без назви'}`;
       image.loading = 'lazy';
       image.className = 'exhibitions-table__image';
-      imageCell.appendChild(image);
+
+      imageButton.appendChild(image);
+      imageButton.addEventListener('click', () =>
+        openExhibitionImage({
+          imageUrl: exhibition.imageUrl,
+          name: exhibition.name,
+        })
+      );
+
+      imageCell.appendChild(imageButton);
     } else {
       imageCell.textContent = '—';
     }

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -275,6 +275,29 @@
   background-color: #dfe5e8;
 }
 
+.exhibitions-table__image-button {
+  display: inline-flex;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: none;
+  cursor: zoom-in;
+}
+
+.exhibitions-table__image-button:focus-visible {
+  outline: 2px solid #2b333a;
+  outline-offset: 2px;
+}
+
+.exhibitions-lightbox__image {
+  max-width: 90vw;
+  max-height: 90vh;
+  width: auto;
+  height: auto;
+  border-radius: 12px;
+  object-fit: contain;
+}
+
 .exhibitions-message {
   margin-top: 16px;
   font-size: 14px;


### PR DESCRIPTION
## Summary
- load the BasicLightbox assets on the exhibitions page
- wrap exhibition thumbnails with a zoom-trigger button
- open a modal preview and style controls for enlarged images

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6906a01427a4833182f02093e5ea6155