### PR TITLE
Refactor admin and exhibitions pages to use Bulma components

### DIFF
--- a/frontend/Exhibitions.html
+++ b/frontend/Exhibitions.html
@@ -13,52 +13,71 @@
     />
     <link
       rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
+    />
+    <link
+      rel="stylesheet"
       href="https://unpkg.com/basiclightbox@5/dist/basicLightbox.min.css"
     />
     <link rel="stylesheet" href="./styles/main.css" />
   </head>
-  <body class="auth-page">
-    <div class="auth-card">
-      <h1 class="auth-title">Мій профіль</h1>
-      <p class="auth-actions" id="user-email"></p>
-      <div class="table-wrapper">
-        <table class="profile-table">
-          <tbody id="profile-table-body"></tbody>
-        </table>
-      </div>
+  <body class="has-background-light">
+    <section class="section">
+      <div class="container">
+        <div class="card">
+          <div class="card-content">
+            <div class="content">
+              <h1 class="title is-3">Мій профіль</h1>
+              <p class="subtitle is-6" id="user-email"></p>
+            </div>
+            <div class="table-container">
+              <table class="table is-fullwidth" aria-describedby="user-email">
+                <tbody id="profile-table-body"></tbody>
+              </table>
+            </div>
 
-      <section class="exhibitions-card">
-        <h2 class="exhibitions-title">Доступні виставки</h2>
-        <p class="exhibitions-subtitle">
-          Перегляньте актуальні виставки та оберіть ту, що вас зацікавила.
-        </p>
-        <div class="table-wrapper exhibitions-table-wrapper">
-          <table class="exhibitions-table" id="exhibitions-table">
-            <thead>
-              <tr>
-                <th scope="col">Зображення</th>
-                <th scope="col">Назва</th>
-                <th scope="col">Період</th>
-                <th scope="col">Вільні місця</th>
-                <th scope="col">Адміністратор</th>
-              </tr>
-            </thead>
-            <tbody id="exhibitions-table-body"></tbody>
-          </table>
-          <p
-            class="exhibitions-message"
-            id="exhibitions-message"
-            hidden
-            aria-live="polite"
-          ></p>
+            <section class="section pt-5 pb-0">
+              <div class="content">
+                <h2 class="title is-4">Доступні виставки</h2>
+                <p class="subtitle is-6">
+                  Перегляньте актуальні виставки та оберіть ту, що вас зацікавила.
+                </p>
+              </div>
+              <div class="table-container">
+                <table
+                  class="table is-fullwidth is-striped is-hoverable"
+                  id="exhibitions-table"
+                >
+                  <thead>
+                    <tr>
+                      <th scope="col">Зображення</th>
+                      <th scope="col">Назва</th>
+                      <th scope="col">Період</th>
+                      <th scope="col">Вільні місця</th>
+                      <th scope="col">Адміністратор</th>
+                    </tr>
+                  </thead>
+                  <tbody id="exhibitions-table-body"></tbody>
+                </table>
+              </div>
+              <div
+                class="notification is-light is-info mt-4"
+                id="exhibitions-message"
+                hidden
+                aria-live="polite"
+              ></div>
+            </section>
+
+            <div class="mt-5">
+              <button class="button is-link is-fullwidth" id="logout-button" type="button">
+                Вийти
+              </button>
+            </div>
+          </div>
         </div>
-      </section>
-
-      <div class="auth-actions">
-        <button class="auth-submit" id="logout-button" type="button">Вийти</button>
       </div>
-    </div>
-
+    </section>
+  
     <script src="https://unpkg.com/basiclightbox@5/dist/basicLightbox.min.js"></script>
     <script type="module" src="./scripts/exhibitions.js"></script>
   </body>

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -11,352 +11,209 @@
       href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
       rel="stylesheet"
     />
-    <style>
-      :root {
-        color-scheme: light;
-        font-family: "IBM Plex Sans", "Montserrat", system-ui, -apple-system,
-          BlinkMacSystemFont, "Segoe UI", sans-serif;
-      }
-
-      body {
-        margin: 0;
-        background-color: #f5f5f5;
-        color: #1d1f22;
-        font-family: inherit;
-      }
-
-      header {
-        background-color: #1d1f22;
-        color: #fff;
-        padding: 1.5rem;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-      }
-
-      header h1 {
-        margin: 0;
-        font-size: 1.5rem;
-      }
-
-      header button {
-        border: none;
-        padding: 0.5rem 1rem;
-        border-radius: 4px;
-        cursor: pointer;
-        background-color: #fff;
-        color: #1d1f22;
-        font-weight: 600;
-        font-family: inherit;
-      }
-
-      main {
-        padding: 2rem 1rem 4rem;
-        /* max-width: 960px; */
-        margin: 0 auto;
-      }
-
-      section {
-        background-color: #fff;
-        border-radius: 12px;
-        padding: 1.5rem;
-        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
-        margin-bottom: 1.5rem;
-      }
-
-      h2 {
-        margin-top: 0;
-        margin-bottom: 1rem;
-        font-size: 1.25rem;
-      }
-
-      form {
-        display: grid;
-        gap: 1rem;
-      }
-
-      .form-actions {
-        display: flex;
-        gap: 0.75rem;
-        flex-wrap: wrap;
-      }
-
-      label {
-        display: grid;
-        gap: 0.5rem;
-      }
-
-      input,
-      textarea,
-      select {
-        padding: 0.75rem;
-        border: 1px solid #cfd1d6;
-        border-radius: 6px;
-        font-size: 1rem;
-        font-family: inherit;
-      }
-
-      button[type="submit"],
-      .table-button {
-        background-color: #1d1f22;
-        color: #fff;
-        border: none;
-        padding: 0.75rem 1.25rem;
-        border-radius: 6px;
-        cursor: pointer;
-        font-weight: 600;
-        font-family: inherit;
-        transition: opacity 0.2s ease;
-      }
-
-      button[type="submit"]:hover,
-      .table-button:hover,
-      header button:hover,
-      .secondary-button:hover {
-        opacity: 0.85;
-      }
-
-      button {
-        font-family: inherit;
-      }
-
-      .secondary-button {
-        background-color: #e0e3e7;
-        color: #1d1f22;
-        font-family: inherit;
-      }
-
-      .input-error {
-        border-color: #c62828;
-        /* background-color: #fdecea; */
-        box-shadow: 0 0 0 3px rgba(211, 47, 47, 0.12);
-      }
-
-      .field-error {
-        color: #c62828;
-        font-size: 0.875rem;
-        margin: 0;
-      }
-
-      table {
-        width: 100%;
-        border-collapse: collapse;
-        font-size: 0.95rem;
-      }
-
-      thead {
-        background-color: #f0f0f0;
-      }
-
-      th,
-      td {
-        padding: 0.75rem;
-        border-bottom: 1px solid #e2e4e9;
-        text-align: left;
-        vertical-align: top;
-      }
-
-      tbody tr:last-child td {
-        border-bottom: none;
-      }
-
-      .table-actions {
-        display: flex;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-      }
-
-      .table-button.delete {
-        background-color: #c62828;
-      }
-
-      .hidden {
-        display: none !important;
-      }
-
-      @media (max-width: 720px) {
-        table,
-        thead,
-        tbody,
-        th,
-        td,
-        tr {
-          display: block;
-        }
-
-        thead {
-          display: none;
-        }
-
-        tr {
-          border: 1px solid #e2e4e9;
-          border-radius: 8px;
-          margin-bottom: 1rem;
-          padding: 0.5rem 0.75rem;
-          background-color: #fff;
-        }
-
-        td {
-          border: none;
-          padding: 0.5rem 0;
-        }
-
-        td::before {
-          content: attr(data-label);
-          display: block;
-          font-weight: 600;
-          margin-bottom: 0.25rem;
-          color: #6b6f76;
-        }
-
-        .table-actions {
-          justify-content: flex-start;
-        }
-      }
-    </style>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
+    />
   </head>
-  <body>
-    <header>
-      <h1>Адмін-панель музею</h1>
-      <button id="logoutButton" class="hidden" type="button">Вийти</button>
-    </header>
-    <main>
-      <section id="loginSection">
-        <h2>Вхід для адміністраторів</h2>
-        <form id="adminLoginForm">
-          <label>
-            Електронна пошта
-            <input
-              type="email"
-              id="adminEmail"
-              name="email"
-              required
-              autocomplete="email"
-            />
-          </label>
-          <label>
-            Пароль
-            <input
-              type="password"
-              id="adminPassword"
-              name="password"
-              required
-              autocomplete="current-password"
-            />
-          </label>
-          <button type="submit">Увійти</button>
-        </form>
-      </section>
-
-      <section id="managementSection" class="hidden">
-        <h2>Керування виставками</h2>
-        <div id="exhibitionApp">
-          <form @submit.prevent="handleSubmit">
-            <label>
-              Назва виставки
-              <input
-                v-model.trim="form.name"
-                :class="{ 'input-error': nameErrorVisible }"
-                type="text"
-                name="name"
-                required
-                @blur="markTouched('name')"
-              />
-              <p v-if="nameErrorVisible" class="field-error">
-                {{ errors.name }}
-              </p>
-            </label>
-            <label>
-              Посилання на зображення (опційно)
-              <input
-                v-model.trim="form.imageUrl"
-                :class="{ 'input-error': imageErrorVisible }"
-                type="url"
-                name="imageUrl"
-                placeholder="https://"
-                @blur="markTouched('imageUrl')"
-              />
-              <p v-if="imageErrorVisible" class="field-error">
-                {{ errors.imageUrl }}
-              </p>
-            </label>
-            <label>
-              Дата початку
-              <input
-                v-model="form.startDate"
-                :class="{ 'input-error': startDateErrorVisible }"
-                type="date"
-                name="startDate"
-                required
-                @blur="markTouched('startDate')"
-              />
-              <p v-if="startDateErrorVisible" class="field-error">
-                {{ errors.startDate }}
-              </p>
-            </label>
-            <label>
-              Дата завершення
-              <input
-                v-model="form.endDate"
-                :class="{ 'input-error': endDateErrorVisible }"
-                type="date"
-                name="endDate"
-                required
-                @blur="markTouched('endDate')"
-              />
-              <p v-if="endDateErrorVisible" class="field-error">
-                {{ errors.endDate }}
-              </p>
-            </label>
-            <label>
-              Доступні місця
-              <input
-                v-model.trim="form.availableSeats"
-                :class="{ 'input-error': seatsErrorVisible }"
-                type="number"
-                name="availableSeats"
-                min="0"
-                step="1"
-                required
-                @blur="markTouched('availableSeats')"
-              />
-              <p v-if="seatsErrorVisible" class="field-error">
-                {{ errors.availableSeats }}
-              </p>
-            </label>
-            <div class="form-actions">
-              <button type="submit" :disabled="isSubmitting">
-                {{ submitLabel }}
-              </button>
-              <button
-                type="button"
-                id="resetFormButton"
-                class="secondary-button"
-                :disabled="isSubmitting"
-                @click="resetForm()"
-              >
-                Очистити форму
+  <body class="has-background-light">
+    <nav class="navbar is-dark" role="navigation" aria-label="main navigation">
+      <div class="container">
+        <div class="navbar-brand">
+          <span class="navbar-item has-text-weight-semibold">
+            Адмін-панель музею
+          </span>
+        </div>
+        <div class="navbar-menu is-active">
+          <div class="navbar-end">
+            <div class="navbar-item">
+              <button id="logoutButton" class="button is-light is-hidden" type="button">
+                Вийти
               </button>
             </div>
-          </form>
+          </div>
         </div>
-      </section>
+      </div>
+    </nav>
 
-      <section id="scheduleSection" class="hidden">
-        <h2>Графік виставок</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>Назва</th>
-              <th>Період</th>
-              <th>Вільні місця</th>
-              <th>Адміністратор</th>
-              <th>Дії</th>
-            </tr>
-          </thead>
-          <tbody id="exhibitionsTableBody"></tbody>
-        </table>
-      </section>
+    <main class="section">
+      <div class="container">
+        <section id="loginSection" class="box">
+          <h2 class="title is-4">Вхід для адміністраторів</h2>
+          <form id="adminLoginForm" class="mt-4">
+            <div class="field">
+              <label class="label" for="adminEmail">Електронна пошта</label>
+              <div class="control">
+                <input
+                  class="input"
+                  type="email"
+                  id="adminEmail"
+                  name="email"
+                  required
+                  autocomplete="email"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="label" for="adminPassword">Пароль</label>
+              <div class="control">
+                <input
+                  class="input"
+                  type="password"
+                  id="adminPassword"
+                  name="password"
+                  required
+                  autocomplete="current-password"
+                />
+              </div>
+            </div>
+
+            <div class="field">
+              <div class="control">
+                <button class="button is-link" type="submit">Увійти</button>
+              </div>
+            </div>
+          </form>
+        </section>
+
+        <section id="managementSection" class="box is-hidden">
+          <h2 class="title is-4">Керування виставками</h2>
+          <div id="exhibitionApp" class="mt-4">
+            <form @submit.prevent="handleSubmit">
+              <div class="field">
+                <label class="label" for="exhibitionName">Назва виставки</label>
+                <div class="control">
+                  <input
+                    id="exhibitionName"
+                    class="input"
+                    v-model.trim="form.name"
+                    :class="{ 'is-danger': nameErrorVisible }"
+                    type="text"
+                    name="name"
+                    required
+                    @blur="markTouched('name')"
+                  />
+                </div>
+                <p v-if="nameErrorVisible" class="help is-danger">
+                  {{ errors.name }}
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label" for="exhibitionImage">Посилання на зображення (опційно)</label>
+                <div class="control">
+                  <input
+                    id="exhibitionImage"
+                    class="input"
+                    v-model.trim="form.imageUrl"
+                    :class="{ 'is-danger': imageErrorVisible }"
+                    type="url"
+                    name="imageUrl"
+                    placeholder="https://"
+                    @blur="markTouched('imageUrl')"
+                  />
+                </div>
+                <p v-if="imageErrorVisible" class="help is-danger">
+                  {{ errors.imageUrl }}
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label" for="exhibitionStartDate">Дата початку</label>
+                <div class="control">
+                  <input
+                    id="exhibitionStartDate"
+                    class="input"
+                    v-model="form.startDate"
+                    :class="{ 'is-danger': startDateErrorVisible }"
+                    type="date"
+                    name="startDate"
+                    required
+                    @blur="markTouched('startDate')"
+                  />
+                </div>
+                <p v-if="startDateErrorVisible" class="help is-danger">
+                  {{ errors.startDate }}
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label" for="exhibitionEndDate">Дата завершення</label>
+                <div class="control">
+                  <input
+                    id="exhibitionEndDate"
+                    class="input"
+                    v-model="form.endDate"
+                    :class="{ 'is-danger': endDateErrorVisible }"
+                    type="date"
+                    name="endDate"
+                    required
+                    @blur="markTouched('endDate')"
+                  />
+                </div>
+                <p v-if="endDateErrorVisible" class="help is-danger">
+                  {{ errors.endDate }}
+                </p>
+              </div>
+
+              <div class="field">
+                <label class="label" for="exhibitionSeats">Доступні місця</label>
+                <div class="control">
+                  <input
+                    id="exhibitionSeats"
+                    class="input"
+                    v-model.trim="form.availableSeats"
+                    :class="{ 'is-danger': seatsErrorVisible }"
+                    type="number"
+                    name="availableSeats"
+                    min="0"
+                    step="1"
+                    required
+                    @blur="markTouched('availableSeats')"
+                  />
+                </div>
+                <p v-if="seatsErrorVisible" class="help is-danger">
+                  {{ errors.availableSeats }}
+                </p>
+              </div>
+
+              <div class="buttons">
+                <button class="button is-link" type="submit" :disabled="isSubmitting">
+                  {{ submitLabel }}
+                </button>
+                <button
+                  class="button is-light"
+                  type="button"
+                  id="resetFormButton"
+                  :disabled="isSubmitting"
+                  @click="resetForm()"
+                >
+                  Очистити форму
+                </button>
+              </div>
+            </form>
+          </div>
+        </section>
+
+        <section id="scheduleSection" class="box is-hidden">
+          <h2 class="title is-4">Графік виставок</h2>
+          <div class="table-container mt-4">
+            <table class="table is-fullwidth is-striped is-hoverable">
+              <thead>
+                <tr>
+                  <th>Назва</th>
+                  <th>Період</th>
+                  <th>Вільні місця</th>
+                  <th>Адміністратор</th>
+                  <th>Дії</th>
+                </tr>
+              </thead>
+              <tbody id="exhibitionsTableBody"></tbody>
+            </table>
+          </div>
+        </section>
+      </div>
     </main>
 
     <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>

--- a/frontend/scripts/admin.js
+++ b/frontend/scripts/admin.js
@@ -439,22 +439,25 @@ function renderTable(exhibitions) {
 
     const actionsCell = document.createElement('td');
     actionsCell.dataset.label = 'Дії';
-    actionsCell.className = 'table-actions';
+
+    const actionsWrapper = document.createElement('div');
+    actionsWrapper.className = 'buttons are-small';
 
     const editButton = document.createElement('button');
     editButton.type = 'button';
-    editButton.className = 'table-button';
+    editButton.className = 'button is-info is-light';
     editButton.textContent = 'Редагувати';
     editButton.addEventListener('click', () => openExhibitionEditor(exhibition));
 
     const deleteButton = document.createElement('button');
     deleteButton.type = 'button';
-    deleteButton.className = 'table-button delete';
+    deleteButton.className = 'button is-danger is-light';
     deleteButton.textContent = 'Видалити';
     deleteButton.addEventListener('click', () => handleDelete(exhibition.id));
 
-    actionsCell.appendChild(editButton);
-    actionsCell.appendChild(deleteButton);
+    actionsWrapper.appendChild(editButton);
+    actionsWrapper.appendChild(deleteButton);
+    actionsCell.appendChild(actionsWrapper);
     row.appendChild(actionsCell);
 
     tbody.appendChild(row);
@@ -535,15 +538,15 @@ function toggleVisibility(isAuthorized) {
   const logoutButton = document.getElementById('logoutButton');
 
   if (isAuthorized) {
-    loginSection.classList.add('hidden');
-    managementSection.classList.remove('hidden');
-    scheduleSection.classList.remove('hidden');
-    logoutButton.classList.remove('hidden');
+    loginSection.classList.add('is-hidden');
+    managementSection.classList.remove('is-hidden');
+    scheduleSection.classList.remove('is-hidden');
+    logoutButton.classList.remove('is-hidden');
   } else {
-    loginSection.classList.remove('hidden');
-    managementSection.classList.add('hidden');
-    scheduleSection.classList.add('hidden');
-    logoutButton.classList.add('hidden');
+    loginSection.classList.remove('is-hidden');
+    managementSection.classList.add('is-hidden');
+    scheduleSection.classList.add('is-hidden');
+    logoutButton.classList.add('is-hidden');
   }
 }
 

--- a/frontend/scripts/exhibitions.js
+++ b/frontend/scripts/exhibitions.js
@@ -14,11 +14,8 @@ function setExhibitionsMessage(text, options = {}) {
   exhibitionsMessage.textContent = text || '';
   exhibitionsMessage.hidden = !text;
 
-  if (isError) {
-    exhibitionsMessage.classList.add('exhibitions-message--error');
-  } else {
-    exhibitionsMessage.classList.remove('exhibitions-message--error');
-  }
+  exhibitionsMessage.classList.toggle('is-danger', Boolean(isError));
+  exhibitionsMessage.classList.toggle('is-info', !isError);
 }
 
 function formatDate(value) {
@@ -90,7 +87,7 @@ function renderExhibitions(exhibitions) {
     if (exhibition.imageUrl) {
       const imageButton = document.createElement('button');
       imageButton.type = 'button';
-      imageButton.className = 'exhibitions-table__image-button';
+      imageButton.className = 'button is-white is-small exhibitions-table__image-button';
 
       const image = document.createElement('img');
       image.src = exhibition.imageUrl;
@@ -157,11 +154,11 @@ function renderUserDetails(user) {
     const tr = document.createElement('tr');
     const tdLabel = document.createElement('td');
     tdLabel.textContent = row.label;
-    tdLabel.className = 'profile-table__label';
+    tdLabel.className = 'has-text-weight-semibold has-text-dark';
 
     const tdValue = document.createElement('td');
     tdValue.textContent = row.value;
-    tdValue.className = 'profile-table__value';
+    tdValue.className = 'has-text-grey-darker';
 
     tr.appendChild(tdLabel);
     tr.appendChild(tdValue);


### PR DESCRIPTION
## Summary
- restyled Exhibitions.html using Bulma cards, tables, and buttons while keeping existing functionality
- reworked admin.html markup to adopt Bulma layout, form, and table classes for a cleaner UI
- updated related scripts to align dynamic elements with Bulma styling and visibility helpers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6907b148993c8331b25ce690eedddfdf