### PR TITLE
Fix exhibition image layout in table

### DIFF
--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -267,21 +267,31 @@
   background-color: #f9fbfc;
 }
 
-.exhibitions-table__image {
-  width: 80px;
-  height: 64px;
-  border-radius: 8px;
-  object-fit: cover;
-  background-color: #dfe5e8;
+.exhibitions-table td:first-child {
+  width: 136px;
 }
 
 .exhibitions-table__image-button {
   display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 120px;
+  aspect-ratio: 4 / 3;
   padding: 0;
   border: none;
   border-radius: 8px;
   background: none;
   cursor: zoom-in;
+  overflow: hidden;
+}
+
+.exhibitions-table__image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  object-fit: cover;
+  background-color: #dfe5e8;
 }
 
 .exhibitions-table__image-button:focus-visible {


### PR DESCRIPTION
## Summary
- constrain the exhibitions table image column width
- ensure exhibition images scale within the button wrapper without overflowing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907d3bfaaa083319905b3efbd478a04