### PR TITLE
Add account settings page with user management actions

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -76,7 +76,7 @@ async function findAdminById(adminId) {
 }
 
 function normalizePhone(phone) {
-  if (!phone) {
+  if (typeof phone !== 'string') {
     return null;
   }
 
@@ -194,6 +194,181 @@ app.post('/api/login', async (req, res) => {
     return res
       .status(500)
       .json({ error: 'Сталася помилка під час авторизації.' });
+  }
+});
+
+app.put('/api/users/:id', async (req, res) => {
+  const userId = Number(req.params.id);
+
+  if (!Number.isInteger(userId) || userId <= 0) {
+    return res
+      .status(400)
+      .json({ error: 'Некоректний ідентифікатор користувача.' });
+  }
+
+  const { email, phone, password, currentPassword } = req.body || {};
+
+  if (
+    email === undefined &&
+    phone === undefined &&
+    password === undefined
+  ) {
+    return res
+      .status(400)
+      .json({ error: 'Не вказано даних для оновлення.' });
+  }
+
+  try {
+    const [rows] = await pool.execute(
+      `SELECT id, first_name, last_name, birth_date, gender, email, phone, password
+         FROM Users
+        WHERE id = ?`,
+      [userId]
+    );
+
+    if (!rows.length) {
+      return res.status(404).json({ error: 'Користувача не знайдено.' });
+    }
+
+    const dbUser = rows[0];
+    const updates = [];
+    const params = [];
+
+    if (email !== undefined) {
+      if (typeof email !== 'string') {
+        return res.status(400).json({ error: 'Некоректна електронна пошта.' });
+      }
+
+      const normalizedEmail = email.trim().toLowerCase();
+
+      if (!normalizedEmail) {
+        return res.status(400).json({ error: 'Некоректна електронна пошта.' });
+      }
+
+      if (normalizedEmail !== dbUser.email) {
+        const [existingEmailRows] = await pool.execute(
+          `SELECT id FROM Users WHERE email = ? AND id <> ?`,
+          [normalizedEmail, userId]
+        );
+
+        if (existingEmailRows.length) {
+          return res
+            .status(409)
+            .json({ error: 'Користувач з такою електронною поштою вже існує.' });
+        }
+
+        updates.push('email = ?');
+        params.push(normalizedEmail);
+      }
+    }
+
+    if (phone !== undefined) {
+      let normalizedPhone = null;
+
+      if (phone === null) {
+        normalizedPhone = null;
+      } else if (typeof phone === 'string') {
+        normalizedPhone = normalizePhone(phone);
+      } else {
+        return res.status(400).json({ error: 'Некоректний номер телефону.' });
+      }
+
+      const currentPhone =
+        typeof dbUser.phone === 'string' ? normalizePhone(dbUser.phone) : null;
+
+      if (normalizedPhone !== currentPhone) {
+        updates.push('phone = ?');
+        params.push(normalizedPhone);
+      }
+    }
+
+    if (password !== undefined) {
+      if (typeof password !== 'string' || !password.trim()) {
+        return res
+          .status(400)
+          .json({ error: 'Новий пароль не може бути порожнім.' });
+      }
+
+      if (password.trim().length < 6) {
+        return res
+          .status(400)
+          .json({ error: 'Пароль має містити щонайменше 6 символів.' });
+      }
+
+      if (!currentPassword || typeof currentPassword !== 'string') {
+        return res
+          .status(400)
+          .json({ error: 'Поточний пароль є обов\'язковим.' });
+      }
+
+      let passwordsMatch = false;
+
+      try {
+        passwordsMatch = await bcrypt.compare(currentPassword, dbUser.password);
+      } catch (compareError) {
+        console.warn('User password compare warning:', compareError);
+      }
+
+      if (!passwordsMatch) {
+        return res
+          .status(400)
+          .json({ error: 'Поточний пароль вказано невірно.' });
+      }
+
+      const hashedPassword = await bcrypt.hash(password, 10);
+      updates.push('password = ?');
+      params.push(hashedPassword);
+    }
+
+    if (!updates.length) {
+      return res.json({ user: mapUser(dbUser) });
+    }
+
+    const updateQuery = `UPDATE Users SET ${updates.join(', ')} WHERE id = ?`;
+    params.push(userId);
+
+    await pool.execute(updateQuery, params);
+
+    const [updatedRows] = await pool.execute(
+      `SELECT id, first_name, last_name, birth_date, gender, email, phone
+         FROM Users
+        WHERE id = ?`,
+      [userId]
+    );
+
+    return res.json({ user: mapUser(updatedRows[0]) });
+  } catch (error) {
+    console.error('User update error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Не вдалося оновити дані акаунту.' });
+  }
+});
+
+app.delete('/api/users/:id', async (req, res) => {
+  const userId = Number(req.params.id);
+
+  if (!Number.isInteger(userId) || userId <= 0) {
+    return res
+      .status(400)
+      .json({ error: 'Некоректний ідентифікатор користувача.' });
+  }
+
+  try {
+    const [result] = await pool.execute(`DELETE FROM Users WHERE id = ?`, [
+      userId,
+    ]);
+
+    if (!result.affectedRows) {
+      return res.status(404).json({ error: 'Користувача не знайдено.' });
+    }
+
+    return res.status(204).send();
+  } catch (error) {
+    console.error('User delete error:', error);
+    return res
+      .status(500)
+      .json({ error: 'Не вдалося видалити акаунт.' });
   }
 });
 

--- a/frontend/Exhibitions.html
+++ b/frontend/Exhibitions.html
@@ -26,14 +26,18 @@
       <div class="container">
         <div class="card">
           <div class="card-content">
-            <div class="content">
-              <h1 class="title is-3">Мій профіль</h1>
-              <p class="subtitle is-6" id="user-email"></p>
-            </div>
-            <div class="table-container">
-              <table class="table is-fullwidth" aria-describedby="user-email">
-                <tbody id="profile-table-body"></tbody>
-              </table>
+            <div class="exhibitions-page-header">
+              <div class="content">
+                <h1 class="title is-3">Мій профіль</h1>
+                <p class="subtitle is-6" id="user-email"></p>
+              </div>
+              <a
+                class="button is-link is-light exhibitions-settings-button"
+                id="account-settings-link"
+                href="./settings.html"
+              >
+                Налаштування акаунту
+              </a>
             </div>
 
             <section class="section pt-5 pb-0">

--- a/frontend/scripts/exhibitions.js
+++ b/frontend/scripts/exhibitions.js
@@ -1,8 +1,8 @@
-const profileTableBody = document.getElementById("profile-table-body");
 const emailElement = document.getElementById("user-email");
 const logoutButton = document.getElementById("logout-button");
 const exhibitionsGrid = document.getElementById("exhibitions-grid");
 const exhibitionsMessage = document.getElementById("exhibitions-message");
+const accountSettingsLink = document.getElementById("account-settings-link");
 
 function setExhibitionsMessage(text, options = {}) {
   if (!exhibitionsMessage) {
@@ -154,37 +154,6 @@ function renderExhibitions(exhibitions) {
   setExhibitionsMessage("");
 }
 
-function renderUserDetails(user) {
-  if (!user || !profileTableBody) {
-    return;
-  }
-
-  const rows = [
-    { label: "Ім'я", value: user.firstName || "-" },
-    { label: "Прізвище", value: user.lastName || "-" },
-    { label: "Дата народження", value: user.birthDate || "-" },
-    { label: "Стать", value: user.gender || "-" },
-    { label: "Телефон", value: user.phone || "-" },
-  ];
-
-  profileTableBody.innerHTML = "";
-
-  rows.forEach((row) => {
-    const tr = document.createElement("tr");
-    const tdLabel = document.createElement("td");
-    tdLabel.textContent = row.label;
-    tdLabel.className = "has-text-weight-semibold has-text-dark";
-
-    const tdValue = document.createElement("td");
-    tdValue.textContent = row.value;
-    tdValue.className = "has-text-grey-darker";
-
-    tr.appendChild(tdLabel);
-    tr.appendChild(tdValue);
-    profileTableBody.appendChild(tr);
-  });
-}
-
 async function loadExhibitions() {
   if (!exhibitionsGrid) {
     return;
@@ -235,7 +204,9 @@ function init() {
     emailElement.textContent = user.email || "";
   }
 
-  renderUserDetails(user);
+  if (accountSettingsLink) {
+    accountSettingsLink.href = "./settings.html";
+  }
   loadExhibitions();
 }
 

--- a/frontend/scripts/settings.js
+++ b/frontend/scripts/settings.js
@@ -17,6 +17,8 @@ const confirmDeleteButton = document.getElementById("confirm-delete-button");
 
 let currentUser = null;
 
+const PHONE_REGEX = /^\+380\d{9}$/;
+
 function showMessage(text, options = {}) {
   if (!messageElement) {
     return;
@@ -240,9 +242,19 @@ if (phoneForm) {
     event.preventDefault();
 
     const rawPhone = (phoneInput?.value || "").trim();
-    const payload = { phone: rawPhone || null };
+    const normalizedPhone = rawPhone.replace(/\s+/g, "");
 
-    if (currentUser && (currentUser.phone || "") === rawPhone) {
+    if (normalizedPhone && !PHONE_REGEX.test(normalizedPhone)) {
+      showMessage("Номер телефону має бути у форматі +380XXXXXXXXX.", {
+        isError: true,
+      });
+      return;
+    }
+
+    const payload = { phone: normalizedPhone || null };
+    const currentNormalizedPhone = (currentUser?.phone || "").replace(/\s+/g, "");
+
+    if (normalizedPhone === currentNormalizedPhone) {
       showMessage("Номер телефону не змінився.", { isError: true });
       return;
     }

--- a/frontend/scripts/settings.js
+++ b/frontend/scripts/settings.js
@@ -1,0 +1,343 @@
+const emailElement = document.getElementById("settings-user-email");
+const profileTableBody = document.getElementById("settings-profile-table");
+const messageElement = document.getElementById("settings-message");
+const emailForm = document.getElementById("email-form");
+const phoneForm = document.getElementById("phone-form");
+const passwordForm = document.getElementById("password-form");
+const emailInput = document.getElementById("email-input");
+const phoneInput = document.getElementById("phone-input");
+const currentPasswordInput = document.getElementById("current-password-input");
+const newPasswordInput = document.getElementById("new-password-input");
+const confirmPasswordInput = document.getElementById("confirm-password-input");
+const deleteAccountButton = document.getElementById("delete-account-button");
+const deleteModal = document.getElementById("delete-account-modal");
+const closeDeleteModalButton = document.getElementById("close-delete-modal");
+const cancelDeleteButton = document.getElementById("cancel-delete-button");
+const confirmDeleteButton = document.getElementById("confirm-delete-button");
+
+let currentUser = null;
+
+function showMessage(text, options = {}) {
+  if (!messageElement) {
+    return;
+  }
+
+  const { isError = false } = options;
+
+  messageElement.textContent = text || "";
+
+  messageElement.classList.remove("is-danger", "is-success", "is-info");
+
+  if (!text) {
+    messageElement.classList.add("is-hidden");
+    return;
+  }
+
+  messageElement.classList.remove("is-hidden");
+  messageElement.classList.add(isError ? "is-danger" : "is-success");
+}
+
+function renderProfileTable(user) {
+  if (!profileTableBody) {
+    return;
+  }
+
+  const rows = [
+    { label: "Ім'я", value: user.firstName || "—" },
+    { label: "Прізвище", value: user.lastName || "—" },
+    { label: "Дата народження", value: user.birthDate || "—" },
+    { label: "Стать", value: user.gender || "—" },
+    { label: "Електронна пошта", value: user.email || "—" },
+    { label: "Телефон", value: user.phone || "—" },
+  ];
+
+  profileTableBody.innerHTML = "";
+
+  rows.forEach((row) => {
+    const tr = document.createElement("tr");
+
+    const tdLabel = document.createElement("td");
+    tdLabel.textContent = row.label;
+    tdLabel.className = "has-text-weight-semibold has-text-dark";
+
+    const tdValue = document.createElement("td");
+    tdValue.textContent = row.value;
+    tdValue.className = "has-text-grey-darker";
+
+    tr.appendChild(tdLabel);
+    tr.appendChild(tdValue);
+
+    profileTableBody.appendChild(tr);
+  });
+}
+
+function setCurrentUser(user, options = {}) {
+  if (!user) {
+    return;
+  }
+
+  const { persist = false } = options;
+
+  currentUser = user;
+
+  if (persist) {
+    try {
+      localStorage.setItem("museumUser", JSON.stringify(user));
+    } catch (error) {
+      console.warn("Unable to persist user", error);
+    }
+  }
+
+  if (emailElement) {
+    emailElement.textContent = user.email || "";
+  }
+
+  if (emailInput) {
+    emailInput.value = user.email || "";
+  }
+
+  if (phoneInput) {
+    phoneInput.value = user.phone || "";
+  }
+
+  renderProfileTable(user);
+}
+
+async function updateUserDetails(updatePayload) {
+  if (!currentUser) {
+    throw new Error("Користувача не знайдено.");
+  }
+
+  const response = await fetch(`/api/users/${currentUser.id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(updatePayload),
+  });
+
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const errorMessage = payload.error || "Не вдалося оновити дані акаунту.";
+    throw new Error(errorMessage);
+  }
+
+  if (!payload.user) {
+    throw new Error("Не вдалося отримати оновлені дані користувача.");
+  }
+
+  setCurrentUser(payload.user, { persist: true });
+  return payload.user;
+}
+
+function openDeleteModal() {
+  if (!deleteModal) {
+    return;
+  }
+
+  deleteModal.classList.add("is-active");
+  deleteModal.setAttribute("aria-hidden", "false");
+}
+
+function closeDeleteModal() {
+  if (!deleteModal) {
+    return;
+  }
+
+  deleteModal.classList.remove("is-active");
+  deleteModal.setAttribute("aria-hidden", "true");
+}
+
+async function deleteAccount() {
+  if (!currentUser) {
+    return;
+  }
+
+  if (confirmDeleteButton) {
+    confirmDeleteButton.disabled = true;
+    confirmDeleteButton.classList.add("is-loading");
+  }
+
+  try {
+    const response = await fetch(`/api/users/${currentUser.id}`, {
+      method: "DELETE",
+    });
+
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({}));
+      const errorMessage = payload.error || "Не вдалося видалити акаунт.";
+      throw new Error(errorMessage);
+    }
+
+    localStorage.removeItem("museumUser");
+    closeDeleteModal();
+    window.location.href = "./register.html";
+  } catch (error) {
+    showMessage(error.message || "Не вдалося видалити акаунт.", {
+      isError: true,
+    });
+  } finally {
+    if (confirmDeleteButton) {
+      confirmDeleteButton.disabled = false;
+      confirmDeleteButton.classList.remove("is-loading");
+    }
+  }
+}
+
+function init() {
+  const storedUser = localStorage.getItem("museumUser");
+
+  if (!storedUser) {
+    window.location.href = "./login.html";
+    return;
+  }
+
+  try {
+    const parsedUser = JSON.parse(storedUser);
+    setCurrentUser(parsedUser);
+  } catch (error) {
+    console.error("Unable to parse stored user", error);
+    localStorage.removeItem("museumUser");
+    window.location.href = "./login.html";
+    return;
+  }
+
+  showMessage("");
+}
+
+if (emailForm) {
+  emailForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const nextEmail = (emailInput?.value || "").trim().toLowerCase();
+
+    if (!nextEmail) {
+      showMessage("Введіть нову електронну пошту.", { isError: true });
+      return;
+    }
+
+    if (currentUser && nextEmail === (currentUser.email || "").toLowerCase()) {
+      showMessage("Введена електронна пошта збігається з поточною.", {
+        isError: true,
+      });
+      return;
+    }
+
+    try {
+      await updateUserDetails({ email: nextEmail });
+      showMessage("Електронну пошту оновлено успішно.");
+    } catch (error) {
+      showMessage(error.message || "Не вдалося оновити електронну пошту.", {
+        isError: true,
+      });
+    }
+  });
+}
+
+if (phoneForm) {
+  phoneForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const rawPhone = (phoneInput?.value || "").trim();
+    const payload = { phone: rawPhone || null };
+
+    if (currentUser && (currentUser.phone || "") === rawPhone) {
+      showMessage("Номер телефону не змінився.", { isError: true });
+      return;
+    }
+
+    try {
+      await updateUserDetails(payload);
+      showMessage("Номер телефону оновлено успішно.");
+    } catch (error) {
+      showMessage(error.message || "Не вдалося оновити номер телефону.", {
+        isError: true,
+      });
+    }
+  });
+}
+
+if (passwordForm) {
+  passwordForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const currentPassword = currentPasswordInput?.value || "";
+    const newPassword = newPasswordInput?.value || "";
+    const confirmPassword = confirmPasswordInput?.value || "";
+
+    if (!currentPassword || !newPassword || !confirmPassword) {
+      showMessage("Будь ласка, заповніть усі поля для зміни пароля.", {
+        isError: true,
+      });
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      showMessage("Новий пароль та його підтвердження не збігаються.", {
+        isError: true,
+      });
+      return;
+    }
+
+    try {
+      await updateUserDetails({
+        password: newPassword,
+        currentPassword,
+      });
+
+      if (currentPasswordInput) {
+        currentPasswordInput.value = "";
+      }
+      if (newPasswordInput) {
+        newPasswordInput.value = "";
+      }
+      if (confirmPasswordInput) {
+        confirmPasswordInput.value = "";
+      }
+
+      showMessage("Пароль успішно змінено.");
+    } catch (error) {
+      showMessage(error.message || "Не вдалося змінити пароль.", {
+        isError: true,
+      });
+    }
+  });
+}
+
+if (deleteAccountButton) {
+  deleteAccountButton.addEventListener("click", () => {
+    showMessage("");
+    openDeleteModal();
+  });
+}
+
+if (closeDeleteModalButton) {
+  closeDeleteModalButton.addEventListener("click", () => {
+    closeDeleteModal();
+  });
+}
+
+if (cancelDeleteButton) {
+  cancelDeleteButton.addEventListener("click", () => {
+    closeDeleteModal();
+  });
+}
+
+if (deleteModal) {
+  const modalBackground = deleteModal.querySelector(".modal-background");
+
+  if (modalBackground) {
+    modalBackground.addEventListener("click", () => {
+      closeDeleteModal();
+    });
+  }
+}
+
+if (confirmDeleteButton) {
+  confirmDeleteButton.addEventListener("click", () => {
+    deleteAccount();
+  });
+}
+
+init();

--- a/frontend/settings.html
+++ b/frontend/settings.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="uk">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Налаштування акаунту — NAMU</title>
+    <link rel="icon" type="image/x-icon" href="./images/NAMU_logo.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100..700;1,100..700&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
+    />
+    <link rel="stylesheet" href="./styles/main.css" />
+  </head>
+  <body class="has-background-light">
+    <section class="section">
+      <div class="container">
+        <div class="card">
+          <div class="card-content">
+            <div class="settings-page-header">
+              <div class="content">
+                <h1 class="title is-3">Налаштування акаунту</h1>
+                <p class="subtitle is-6" id="settings-user-email"></p>
+              </div>
+              <a class="button is-light" href="./Exhibitions.html">
+                ← Повернутися до виставок
+              </a>
+            </div>
+
+            <div
+              id="settings-message"
+              class="notification is-hidden"
+              role="status"
+              aria-live="polite"
+            ></div>
+
+            <div class="table-container mt-4">
+              <table class="table is-fullwidth" aria-describedby="settings-user-email">
+                <tbody id="settings-profile-table"></tbody>
+              </table>
+            </div>
+
+            <div class="settings-forms mt-5">
+              <form class="box" id="email-form">
+                <h2 class="title is-5">Оновити електронну пошту</h2>
+                <div class="field">
+                  <label class="label" for="email-input">Нова електронна пошта</label>
+                  <div class="control">
+                    <input
+                      class="input"
+                      id="email-input"
+                      type="email"
+                      name="email"
+                      autocomplete="email"
+                      required
+                    />
+                  </div>
+                </div>
+                <div class="field is-grouped is-justify-content-flex-end">
+                  <div class="control">
+                    <button class="button is-link" type="submit">Зберегти</button>
+                  </div>
+                </div>
+              </form>
+
+              <form class="box" id="phone-form">
+                <h2 class="title is-5">Оновити номер телефону</h2>
+                <div class="field">
+                  <label class="label" for="phone-input">Новий номер телефону</label>
+                  <div class="control">
+                    <input
+                      class="input"
+                      id="phone-input"
+                      type="tel"
+                      name="phone"
+                      autocomplete="tel"
+                    />
+                  </div>
+                </div>
+                <div class="field is-grouped is-justify-content-flex-end">
+                  <div class="control">
+                    <button class="button is-link" type="submit">Зберегти</button>
+                  </div>
+                </div>
+              </form>
+
+              <form class="box" id="password-form">
+                <h2 class="title is-5">Змінити пароль</h2>
+                <div class="field">
+                  <label class="label" for="current-password-input">Поточний пароль</label>
+                  <div class="control">
+                    <input
+                      class="input"
+                      id="current-password-input"
+                      type="password"
+                      name="currentPassword"
+                      autocomplete="current-password"
+                      required
+                    />
+                  </div>
+                </div>
+                <div class="field">
+                  <label class="label" for="new-password-input">Новий пароль</label>
+                  <div class="control">
+                    <input
+                      class="input"
+                      id="new-password-input"
+                      type="password"
+                      name="newPassword"
+                      autocomplete="new-password"
+                      minlength="6"
+                      required
+                    />
+                  </div>
+                </div>
+                <div class="field">
+                  <label class="label" for="confirm-password-input">Підтвердження нового пароля</label>
+                  <div class="control">
+                    <input
+                      class="input"
+                      id="confirm-password-input"
+                      type="password"
+                      name="confirmPassword"
+                      autocomplete="new-password"
+                      minlength="6"
+                      required
+                    />
+                  </div>
+                </div>
+                <div class="field is-grouped is-justify-content-flex-end">
+                  <div class="control">
+                    <button class="button is-link" type="submit">Оновити пароль</button>
+                  </div>
+                </div>
+              </form>
+
+              <div class="box settings-danger-zone">
+                <h2 class="title is-5 has-text-danger">Видалення акаунту</h2>
+                <p class="mb-4">
+                  Видалення акаунту є незворотнім. Усі ваші дані будуть стерті.
+                </p>
+                <button
+                  class="button is-danger"
+                  type="button"
+                  id="delete-account-button"
+                >
+                  Видалити акаунт
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="modal" id="delete-account-modal" aria-hidden="true">
+      <div class="modal-background"></div>
+      <div class="modal-card">
+        <header class="modal-card-head">
+          <p class="modal-card-title">Підтвердіть видалення</p>
+          <button
+            class="delete"
+            aria-label="Закрити"
+            type="button"
+            id="close-delete-modal"
+          ></button>
+        </header>
+        <section class="modal-card-body">
+          <p>
+            Ви впевнені, що хочете видалити свій акаунт? Цю дію не можна буде
+            скасувати.
+          </p>
+        </section>
+        <footer class="modal-card-foot is-justify-content-flex-end">
+          <button class="button" type="button" id="cancel-delete-button">
+            Скасувати
+          </button>
+          <button
+            class="button is-danger"
+            type="button"
+            id="confirm-delete-button"
+          >
+            Видалити
+          </button>
+        </footer>
+      </div>
+    </div>
+
+    <script type="module" src="./scripts/settings.js"></script>
+  </body>
+</html>

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -400,6 +400,36 @@
   background-color: #dfe5e8;
 }
 
+.exhibitions-page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.exhibitions-settings-button {
+  align-self: flex-start;
+}
+
+.settings-page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.settings-forms {
+  display: grid;
+  gap: 24px;
+}
+
+.settings-danger-zone {
+  border: 1px solid #f14668;
+  background-color: #fff5f7;
+}
+
 .exhibitions-table__image-button {
   display: inline-flex;
   padding: 0;


### PR DESCRIPTION
## Summary
- replace the exhibitions profile table with a link to the new account settings view
- add a settings page and client logic for updating email, phone, password, and deleting the profile with confirmation
- expose backend endpoints for updating and deleting users to persist the new account actions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907dccfe4188331a411b267737ccab7