### PR TITLE
docs: expand backend README with user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ DATABASE_URL=mysql://USER:PASSWORD@HOST:PORT/DATABASE?ssl-mode=DISABLED
 - Optionally set `PORT` to change the default HTTP port (`3000`).
 
 ## Database Model
-| Table        | Columns (required *)                                                                                       | Notes |
-|--------------|------------------------------------------------------------------------------------------------------------|-------|
-| `Users`      | `id`, `first_name*`, `last_name*`, `birth_date*`, `gender`, `email*`, `phone`, `password*`                  | Emails must be unique; passwords are stored as bcrypt hashes. |
-| `Admins`     | `id`, `first_name*`, `last_name*`, `email*`, `password*`                                                    | Used for privileged access to exhibition management. |
-| `Exhibitions`| `id`, `name*`, `image_url`, `start_date*`, `end_date*`, `available_seats*`, `admin_id*`                     | `admin_id` references `Admins.id`; availability must be a non-negative integer. |
+| Table | Key columns (required \*) | Notes |
+|-------|---------------------------|-------|
+| `Users` | `id`, `first_name*`, `last_name*`, `birth_date*`,<br>`gender`, `email*`, `phone`, `password*` | Emails must be unique; passwords are stored as bcrypt hashes. |
+| `Admins` | `id`, `first_name*`, `last_name*`, `email*`, `password*` | Used for privileged access to exhibition management. |
+| `Exhibitions` | `id`, `name*`, `image_url`, `start_date*`, `end_date*`,<br>`available_seats*`, `admin_id*` | `admin_id` references `Admins.id`; availability must be a non-negative integer. |
 
 ## Business Logic and Data Flow
 1. **Registration (`POST /api/register`)**
@@ -63,41 +63,51 @@ DATABASE_URL=mysql://USER:PASSWORD@HOST:PORT/DATABASE?ssl-mode=DISABLED
    - Inserts the user record and immediately fetches it to return the normalized user payload (without password).
    - Handles duplicate emails and general errors with localized error messages.
 
-2. **Visitor login (`POST /api/login`)**
+2. **Account maintenance (`PUT /api/users/:id`)**
+   - Accepts partial updates for `email`, `phone`, and `password`.
+   - Validates uniqueness of the new email and enforces the Ukrainian phone format (`+380XXXXXXXXX`).
+   - Requires `currentPassword` when changing the password and checks it against the stored bcrypt hash.
+   - Returns the updated user profile or surface validation errors.
+
+3. **Account deletion (`DELETE /api/users/:id`)**
+   - Removes the user row when it exists.
+   - Returns `204 No Content` on success and `404 Not Found` when the user cannot be located.
+
+4. **Visitor login (`POST /api/login`)**
    - Validates presence of `email` and `password`.
    - Fetches the user by normalized email and compares the bcrypt hash.
    - Returns the mapped user object when authentication succeeds; otherwise responds with a 401 error.
 
-3. **Public exhibitions (`GET /api/exhibitions`)**
+5. **Public exhibitions (`GET /api/exhibitions`)**
    - Returns exhibitions that still have seats available.
    - Joins `Admins` to include the curator name in the response.
    - Sorts results by start date, end date, and name for deterministic ordering.
 
-4. **Admin login (`POST /api/admin/login`)**
+6. **Admin login (`POST /api/admin/login`)**
    - Normalizes email, fetches admin credentials, and compares hashes.
    - Provides a backward-compatible fallback for legacy plain-text passwords.
    - Returns basic admin profile data on success.
 
-5. **Admin exhibition listing (`GET /api/admin/exhibitions?adminId=ID`)**
+7. **Admin exhibition listing (`GET /api/admin/exhibitions?adminId=ID`)**
    - Requires a valid `adminId` query parameter.
    - Verifies that the admin exists before returning the full exhibition catalog (regardless of seat availability).
 
-6. **Admin exhibition creation (`POST /api/admin/exhibitions`)**
+8. **Admin exhibition creation (`POST /api/admin/exhibitions`)**
    - Requires authenticated admin context (`adminId` in request body).
    - Validates name, dates, and available seats (non-negative integers).
    - Ensures start date is not after end date.
    - Persists the exhibition and returns the normalized entity, including admin metadata.
 
-7. **Admin exhibition update (`PUT /api/admin/exhibitions/:id`)**
+9. **Admin exhibition update (`PUT /api/admin/exhibitions/:id`)**
    - Requires the exhibition ID path parameter and admin context in the body.
    - Validates payload similar to creation.
    - Checks that the exhibition belongs to the requesting admin before updating.
 
-8. **Admin exhibition deletion (`DELETE /api/admin/exhibitions/:id?adminId=ID`)**
+10. **Admin exhibition deletion (`DELETE /api/admin/exhibitions/:id?adminId=ID`)**
    - Validates identifiers and ensures the admin owns the exhibition before removing it.
    - Returns `204 No Content` on success.
 
-9. **Health check (`GET /api/health`)**
+11. **Health check (`GET /api/health`)**
    - Returns `{ "status": "ok" }` for monitoring and readiness probes.
 
 ## API Reference
@@ -140,6 +150,37 @@ Authenticates an existing user.
   - `200 OK` with `{ "user": { ... } }`
   - `400 Bad Request` when email or password is missing
   - `401 Unauthorized` when the email is not found or the password does not match
+  - `500 Internal Server Error` for unexpected issues
+
+#### `PUT /api/users/:id`
+Updates a user's profile.
+
+- **Path Parameters:** `id` (required integer)
+- **Request Body (JSON):**
+  ```json
+  {
+    "email": "ada.new@example.com",
+    "phone": "+380001112233",
+    "password": "newSecret123",
+    "currentPassword": "securePass123"
+  }
+  ```
+  - Omit any fields that should remain unchanged.
+- **Responses:**
+  - `200 OK` with `{ "user": { ... } }`
+  - `400 Bad Request` for invalid identifiers or payloads, missing `currentPassword` when changing the password, or poorly formatted phone numbers
+  - `409 Conflict` when the email is already in use by another account
+  - `404 Not Found` if the user cannot be located
+  - `500 Internal Server Error` for unexpected issues
+
+#### `DELETE /api/users/:id`
+Deletes a user account.
+
+- **Path Parameters:** `id` (required integer)
+- **Responses:**
+  - `204 No Content` on success
+  - `400 Bad Request` for invalid identifiers
+  - `404 Not Found` if the user cannot be located
   - `500 Internal Server Error` for unexpected issues
 
 #### `GET /api/exhibitions`
@@ -235,6 +276,8 @@ The backend interacts with MySQL through parameterized queries to prevent SQL in
 |-------------------------------------------------|------------------|
 | `POST /api/register`                            | `INSERT INTO Users (...) VALUES (?, ?, ?, ?, ?, ?, ?)` and `SELECT ... FROM Users WHERE id = ?` |
 | `POST /api/login`                               | `SELECT ... FROM Users WHERE email = ?` |
+| `PUT /api/users/:id`                            | `SELECT ... FROM Users WHERE id = ?`, optional `SELECT id FROM Users WHERE email = ? AND id <> ?`, `UPDATE Users SET ... WHERE id = ?`, `SELECT ... FROM Users WHERE id = ?` |
+| `DELETE /api/users/:id`                         | `DELETE FROM Users WHERE id = ?` |
 | `GET /api/exhibitions`                          | `SELECT ... FROM Exhibitions e JOIN Admins a ON e.admin_id = a.id WHERE e.available_seats > 0 ORDER BY ...` |
 | `POST /api/admin/login`                         | `SELECT ... FROM Admins WHERE LOWER(email) = ?` |
 | `GET /api/admin/exhibitions`                    | `SELECT ... FROM Exhibitions e JOIN Admins a ON e.admin_id = a.id ORDER BY ...` |


### PR DESCRIPTION
## Summary
- add documentation for the user update and deletion endpoints, including request and response details
- update the business logic overview to describe account maintenance flows alongside existing features
- improve the database model section for readability and note the queries executed for the new routes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6907eb9a84cc83319868927e6119b8ba